### PR TITLE
Provide feedback when donation lambda fails.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Ruby version should match https://pages.github.com/versions/
+FROM ruby:2.7.3-alpine3.13
+
+# Native extensions require compilation
+RUN apk add --update make gcc g++ musl-dev patch
+
+# Bundler version should match the last line in Gemfile.lock
+RUN gem install bundler:1.16.2
+
+WORKDIR /project
+COPY Gemfile* ./
+RUN bundle update --bundler
+RUN bundle install
+
+ENTRYPOINT ["bundle", "exec", "jekyll"]
+CMD ["serve", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 Note: This repo will soon undergo major cleanup.
 
 More documentation forthcoming :)
+
+
+## Running locally with Docker
+
+To start the site locally with Docker, start by installing and starting the
+Docker engine if it isn’t already installed. Then, run:
+
+```bash
+docker compose up
+```
+
+The site is now accessible at http://localhost:4000. Hit <kbd>CTRL</kbd> + <kbd>C</kbd> to shut down the server.
+
+To rebuild the docker image if the ruby version, gems, or Dockerfile have changed, run `docker compose build`. If you’re experiencing caching problems, try `docker compose build --no-cache`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Code for DC — New Website
+# Code for DC — New Website
 
 Note: This repo will soon undergo major cleanup.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  jekyll:
+    build: ./
+    volumes:
+      - ./:/project
+    ports:
+      - "4000:4000"

--- a/donate.html
+++ b/donate.html
@@ -138,10 +138,11 @@ title: Donate to Code for DC
         $('#special-instructions').attr('disabled', true);
         $('#donationButton').attr('disabled', true);
         $('#donationButton').html('Processing...');
-        $.post(
-          'https://b9sq87esw7.execute-api.us-east-2.amazonaws.com/prod/codefordc-stripe-processor',
-          send,
-          function(data, status) {
+        $.ajax({
+          type: 'POST',
+          url: 'https://b9sq87esw7.execute-api.us-east-2.amazonaws.com/prod/codefordc-stripe-processor',
+          data: send,
+          success: function(data, status) {
             if (data.chargeSuccess) {
               $('#error').hide();
               $('#success h3').html(data.message);
@@ -158,7 +159,17 @@ title: Donate to Code for DC
             $('#donationButton').attr('disabled', false);
             $('#donationButton').html('Make donation');
           },
-        );
+          error: function() {
+            $('#success').hide();
+            $('#error h3').html(`
+              Your donation was successful, but an error occurred when
+              processing your special instructions. Send us a message at
+              team@codefordc.org if you have any special instructions for
+              your donation.
+            `);
+            $('#error').show();
+          }
+        });
       },
     });
     document

--- a/donate.html
+++ b/donate.html
@@ -105,8 +105,7 @@ title: Donate to Code for DC
     let apiKey;
     let account;
     if (
-      window.location.hostname === 'localhost' ||
-      window.location.hostname === '127.0.0.1'
+      ['localhost', '127.0.0.1', '0.0.0.0'].includes(window.location.hostname)
     ) {
       // Check if we are working locally and should use test data.
       apiKey = 'pk_test_NETzOLRKGqVNftlJdCarfUEN';


### PR DESCRIPTION
I donated last week — the donation went through successfully, but the site hung showing "Processing…" and threw some errors to the console. 

Looks like the root cause is that [this lambda is crashing](https://b9sq87esw7.execute-api.us-east-2.amazonaws.com/prod/codefordc-stripe-processor) — I don’t see the code here, but I‘d be happy to take a look. The flow looks like this: 

- User fills out data in the form, and clicks Donate. 
- Stripe modal is presented to gather credit card info and process the payment.
- Stripe modal closes, triggering a callback to the page. 
- The page sets the donate button text to "Processing…" and makes a request out to the above referenced lambda. 
- This request fails on CORS preflight because the response from this lambda doesn’t contain the appropriate CORS headers. (This appears to be because the lambda itself is crashing when handling the CORS preflight). 
- There is no error handler on the request, so the page stays in this state. 

This PR implements a quick and dirty error handler for this post-donation request, and lets the user know that their donation was successful but they might not have had their special instructions saved. (Is this true? I don’t know what that lambda does). 

> Your donation was successful, but an error occurred when processing your special instructions. Send us a message at team@codefordc.org if you have any special instructions for your donation.

Here’s what it looks like: 

![Screenshot of error message referenced above.](https://user-images.githubusercontent.com/14930/149822534-1e740057-208b-4cf7-b442-09106b28809f.png)

-----

Additionally, I don’t have a copy of ruby which is functioning on my machine, so I added a `Dockerfile` and related `docker-compose.yml`, and documented it in the `README`.
