### PR TITLE
Update cib-mango-tree.md to add website link

### DIFF
--- a/_projects/cib-mango-tree.md
+++ b/_projects/cib-mango-tree.md
@@ -10,3 +10,4 @@ description: An integrated library of open source programs to test datasets of s
 ---
 
 An integrated library of open source programs to test datasets of social media activity for signs of coordinated inauthentic behavior (CIB).
+[Website](https://cibmangotree.org/)


### PR DESCRIPTION
This is a small quick fix to add the cib mango tree website to the project page.