### PR TITLE
Fix VoteCatcher GitHub link to civictechdc/votecatcher

### DIFF
--- a/_projects/ballot-initiative.md
+++ b/_projects/ballot-initiative.md
@@ -4,7 +4,7 @@ is_active: true
 title: VoteCatcher
 image: project_thumbnails/ballot-initiative.png
 image_alt_text: Handwritten PDF scans being converted into machine-readable format
-github_link: https://github.com/Civic-Tech-Ballot-Inititiave/Ballot-Initiative
+github_link: https://github.com/civictechdc/votecatcher
 slack_channel: vote_catcher
 description: Building open source campaign infrastructure that any grassroots organizer can use - starting with signature validation processes.
 ---
@@ -68,7 +68,7 @@ description: Building open source campaign infrastructure that any grassroots or
       <a href="https://civictechdc.slack.com/archives/C077YB2ES84" class="usa-button usa-button--dark" target="_blank" rel="noopener noreferrer">
         <span aria-hidden="true">💬</span> Slack (#ballot_initiative)
       </a>
-      <a href="https://github.com/Civic-Tech-Ballot-Inititiave/Ballot-Initiative" class="usa-button usa-button--dark" target="_blank" rel="noopener noreferrer">
+      <a href="https://github.com/civictechdc/votecatcher" class="usa-button usa-button--dark" target="_blank" rel="noopener noreferrer">
         <span aria-hidden="true">🧩</span> GitHub Repo
       </a>
     </div>


### PR DESCRIPTION
The `github_link` frontmatter and the in-page **GitHub Repo** button in `_projects/ballot-initiative.md` both pointed at the old `Civic-Tech-Ballot-Inititiave/Ballot-Initiative` repo (now just a stale redirect). This points both at the canonical active repo, `civictechdc/votecatcher`.

This applies the link fix from #181 cleanly, without that PR's unrelated changes (em-dashes, removed `aria-hidden`, inline styles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)