### PR TITLE
Add Volunteer nav link to employment platform

### DIFF
--- a/_includes/core/header.html
+++ b/_includes/core/header.html
@@ -26,6 +26,11 @@
           </a>
         </li>
         <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="https://platform.civictechdc.org">
+            <span>Volunteer</span>
+          </a>
+        </li>
+        <li class="usa-nav__primary-item">
           <a class="usa-nav__link" href="{{ site.baseurl }}/events"{% if page.url contains '/events' %} aria-current="page"{% endif %}>
             <span>Events</span>
           </a>


### PR DESCRIPTION
## What

Adds a **Volunteer** item to the primary navigation, linking to the Civic Tech DC employment platform at `https://platform.civictechdc.org`.

## Why

The [employment-platform](https://github.com/civictechdc/employment-platform) is a separate Next.js + Supabase app (deployed to Vercel) that lets volunteers browse projects and find where to contribute. Rather than fold a database-backed app into this static Jekyll/GitHub Pages site, the two stay independently deployed and the only contract between them is the URL.

## Changes

- One new `usa-nav__primary-item` in `_includes/core/header.html`, placed after **Projects**.
- It's an absolute outbound link, so it intentionally skips the `aria-current` page-matching logic the internal nav items use.

## Notes / out of scope

- Requires the platform team to point a `CNAME` for `platform.civictechdc.org` at Vercel and add the domain to the Vercel project. **The link 404s until that DNS is live** — merge once the platform is deployed (or accept a temporary dead link).
- No asset regeneration, submodule, or hosting change. `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)