### PR TITLE
Correct two claims introduced by the SEO rewrite

### DIFF
--- a/_projects/clean-slate.md
+++ b/_projects/clean-slate.md
@@ -40,7 +40,7 @@ That boundary mattered. An outdated or incorrect legal answer could prevent some
 
 ## Transition and archive
 
-The Civic Tech DC repository is archived. In March 2016, further development and deployment moved to [Mission Launch's Clean Slate repository](https://github.com/MissionLaunch/clean-slate). Both repositories document a historical project, not a current legal service.
+The Civic Tech DC repository is archived. A March 2016 repository note records the intent to move further development to [Mission Launch's Clean Slate repository](https://github.com/MissionLaunch/clean-slate), though statute-tracking work continued in the Code for DC repository into early 2017. Both repositories document a historical project, not a current legal service.
 
 The available record does not establish a verified number of users, sealed or expunged records, or legal outcomes. Clean Slate's documented value lies in its response to a specific policy change, its partnership with legal practitioners, and its decision to keep attorneys in the review process.
 

--- a/_projects/ridescoredc.md
+++ b/_projects/ridescoredc.md
@@ -34,13 +34,11 @@ The project aims to:
 
 ## An open and reusable method
 
-Ride Score DC draws on established approaches such as Level of Traffic Stress and PeopleForBikes' Bicycle Network Analysis. The [public repository](https://github.com/civictechdc/ridescoredc) contains:
+Ride Score DC draws on established approaches such as Level of Traffic Stress and PeopleForBikes' Bicycle Network Analysis. The work is split across public repositories:
 
-- documented schemas for street segments and score layers;
-- transparent rulesets for established and composite measures;
-- a Python pipeline for ingesting, cleaning, scoring, and exporting data;
-- map layers for scores and source factors;
-- an early web-map implementation.
+- the [main repository](https://github.com/civictechdc/ridescoredc) holds project documentation, onboarding material, and sample data;
+- the [models repository](https://github.com/civictechdc/ridescoredc-models) holds the Python scoring pipeline and early model work, including a first Level of Traffic Stress implementation;
+- the [website repository](https://github.com/civictechdc/ridescoredc-website) holds an early web-map implementation.
 
 DC is the first focus. The open-source method can be adapted by other cities that have suitable crash, roadway, and infrastructure data.
 
@@ -52,7 +50,7 @@ Ride Score DC does not currently name an organizational partner. The team would 
 
 ## Current status and limits
 
-The project is active. Its repository includes sample data, model artifacts, an MVP map, and an initial pipeline; setup, model review, data updates, and rider validation remain in progress.
+The project is active. Across its repositories the team has sample data, early model artifacts, an MVP map, and an initial pipeline; setup, model review, data updates, and rider validation remain in progress.
 
 - Source data may omit near misses, perceived stress, temporary conditions, or recent street changes.
 - A segment score cannot describe an entire trip, intersection risk, weather, construction, or every rider's needs.


### PR DESCRIPTION
Subagent fact-check of all 11 case-study pages (repo evidence vs. pre-rewrite pages vs. July scan). Rule applied: claims inherited from prior pages stay for the factual-review register; only rewrite-introduced claims are corrected here.

- **Ride Score DC**: main repo doesn't contain the claimed schemas/rulesets/layers/pipeline/MVP — those live in ridescoredc-models and ridescoredc-website. Page now points at the right repos.
- **Clean Slate**: "moved to Mission Launch in March 2016" was stated as fact; the repo note records intent, and commits continued into early 2017. Reworded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4R2C2uQr8awfCK5KsCbDm