### PR TITLE
Integrate the ideas archive into the site chrome

### DIFF
--- a/_layouts/full-width.html
+++ b/_layouts/full-width.html
@@ -1,0 +1,7 @@
+---
+layout: base
+---
+{% include core/header.html %}
+<main id="main-content">{{ content }}</main>
+
+{% include core/footer.html %}

--- a/ideas-graveyard/index.html
+++ b/ideas-graveyard/index.html
@@ -1,2100 +1,2119 @@
 ---
-layout: null
+layout: full-width
+title: Ideas Graveyard
+seo_title: "Ideas Graveyard: DC Civic Tech Project Archive"
+description: "Civic Tech DC's records room: buried project ideas worth reviving, projects alive today, and an open drawer for new proposals."
 permalink: /archive-dig/
-sitemap: false
 ---
 
-<!doctype html>
-<html lang="en-US">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="dark" />
-    <meta name="robots" content="noindex, follow" />
-    <title>Ideas Graveyard | Civic Tech DC</title>
-    <meta
-      name="description"
-      content="Civic Tech DC's records room: buried project ideas worth reviving, projects alive today, and an open drawer for new proposals."
-    />
-    <link rel="canonical" href="https://www.civictechdc.org/archive-dig/" />
-    <meta name="author" content="Civic Tech DC" />
-    <meta property="og:locale" content="en_US" />
-    <meta property="og:site_name" content="Civic Tech DC" />
-    <meta property="og:title" content="Ideas Graveyard | Civic Tech DC" />
-    <meta
-      property="og:description"
-      content="Civic Tech DC's records room: buried project ideas worth reviving, projects alive today, and an open drawer for new proposals."
-    />
-    <meta
-      property="og:url"
-      content="https://www.civictechdc.org/archive-dig/"
-    />
-    <meta property="og:type" content="website" />
-    <meta
-      property="og:image"
-      content="https://www.civictechdc.org/assets/images/hero-image-homepage-1200w.jpg"
-    />
-    <meta
-      property="og:image:secure_url"
-      content="https://www.civictechdc.org/assets/images/hero-image-homepage-1200w.jpg"
-    />
-    <meta property="og:image:type" content="image/jpeg" />
-    <meta
-      property="og:image:alt"
-      content="Civic Tech DC volunteers collaborating on laptops around tables at a project night"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Ideas Graveyard | Civic Tech DC" />
-    <meta
-      name="twitter:description"
-      content="Civic Tech DC's records room: buried project ideas worth reviving, projects alive today, and an open drawer for new proposals."
-    />
-    <meta
-      name="twitter:url"
-      content="https://www.civictechdc.org/archive-dig/"
-    />
-    <meta
-      name="twitter:image"
-      content="https://www.civictechdc.org/assets/images/hero-image-homepage-1200w.jpg"
-    />
-    <meta
-      name="twitter:image:alt"
-      content="Civic Tech DC volunteers collaborating on laptops around tables at a project night"
-    />
-    <link
-      rel="icon"
-      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>%F0%9F%97%84%EF%B8%8F</text></svg>"
-    />
-    <style>
-      /* Brand fonts, served from the site's own USWDS assets */
-      @font-face {
-        font-family: "Source Sans Pro";
-        src: url("/assets/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2")
-          format("woff2");
-        font-weight: 400;
-        font-style: normal;
-        font-display: swap;
-      }
-      @font-face {
-        font-family: "Source Sans Pro";
-        src: url("/assets/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2")
-          format("woff2");
-        font-weight: 700;
-        font-style: normal;
-        font-display: swap;
-      }
-      @font-face {
-        font-family: "Source Sans Pro";
-        src: url("/assets/fonts/source-sans-pro/sourcesanspro-italic-webfont.woff2")
-          format("woff2");
-        font-weight: 400;
-        font-style: italic;
-        font-display: swap;
-      }
-      :root {
-        /* Civic Premium Dark anchors (design-system/vision) */
-        --midnight: #0b1a30;
-        --vessel: #061121;
-        /* brand */
-        --primary: #104378;
-        --gold: #eec05e;
-        /* light reading surfaces */
-        --card: #ffffff;
-        --card-2: #f8f9fa;
-        --card-line: #e6e6e6;
-        --ink: #1b1b1b;
-        --ink-soft: #565c65;
-        /* text on dark anchors: no pure white */
-        --on-dark: rgba(255, 255, 255, 0.7);
-        --on-dark-faint: rgba(255, 255, 255, 0.45);
-        --glass: rgba(255, 255, 255, 0.05);
-        --glass-line: rgba(255, 255, 255, 0.12);
-        /* tier stamps (readable on white) */
-        --stamp-top: #104378;
-        --stamp-look: #565c65;
-        --stamp-active: #2f6f4d;
-        --sans:
-          "Source Sans Pro", "Source Sans 3", -apple-system, "Segoe UI",
-          Helvetica, Arial, sans-serif;
-        --mono:
-          "Source Code Pro", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-        --ease: cubic-bezier(0.16, 1, 0.3, 1);
-        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
-        --card-shadow-hover: 0 10px 26px rgba(0, 0, 0, 0.32);
-      }
-      * {
-        box-sizing: border-box;
-      }
-      html {
-        scroll-behavior: smooth;
-      }
-      body {
-        margin: 0;
-        background: linear-gradient(
-            180deg,
-            var(--midnight),
-            var(--vessel) 640px
-          )
-          fixed var(--vessel);
-        color: var(--on-dark);
-        font-family: var(--sans);
-        font-size: 16.5px;
-        line-height: 1.55;
-        -webkit-font-smoothing: antialiased;
-      }
-      .wrap {
-        max-width: 1080px;
-        margin: 0 auto;
-        padding: 0 20px;
-      }
-      a {
-        color: var(--gold);
-      }
-      a:focus-visible,
-      button:focus-visible,
-      summary:focus-visible,
-      input:focus-visible {
-        outline: 2px solid var(--gold);
-        outline-offset: 2px;
-      }
-      .card a:focus-visible,
-      .card summary:focus-visible {
-        outline-color: var(--primary);
-      }
+<style>
+  .archive-dig {
+    --ad-midnight: #0b1a30;
+    --ad-vessel: #061121;
+    --ad-primary: #104378;
+    --ad-gold: #eec05e;
+    --ad-card: #ffffff;
+    --ad-card-2: #f8f9fa;
+    --ad-card-line: #e6e6e6;
+    --ad-ink: #1b1b1b;
+    --ad-ink-soft: #565c65;
+    --ad-on-dark: rgba(255, 255, 255, 0.7);
+    --ad-on-dark-faint: rgba(255, 255, 255, 0.45);
+    --ad-glass: rgba(255, 255, 255, 0.05);
+    --ad-glass-line: rgba(255, 255, 255, 0.12);
+    --ad-stamp-top: #104378;
+    --ad-stamp-active: #2f6f4d;
+    --ad-sans:
+      "Source Sans Pro", "Source Sans 3", -apple-system, "Segoe UI", Helvetica,
+      Arial, sans-serif;
+    --ad-mono:
+      "Source Code Pro", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --ad-ease: cubic-bezier(0.16, 1, 0.3, 1);
+    --ad-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+    --ad-shadow-hover: 0 10px 26px rgba(0, 0, 0, 0.32);
+    /* clearance for the sticky site header when the drawer rail sticks */
+    --ad-header-offset: 68px;
+    background: linear-gradient(
+        180deg,
+        var(--ad-midnight),
+        var(--ad-vessel) 640px
+      )
+      var(--ad-vessel);
+    color: var(--ad-on-dark);
+    font-family: var(--ad-sans);
+    font-size: 16.5px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .archive-dig *,
+  .archive-dig *::before,
+  .archive-dig *::after {
+    box-sizing: border-box;
+  }
+  .archive-dig .ad-wrap {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 0 20px;
+  }
+  .archive-dig a {
+    color: var(--ad-gold);
+  }
+  .archive-dig a:focus-visible,
+  .archive-dig button:focus-visible,
+  .archive-dig summary:focus-visible,
+  .archive-dig input:focus-visible {
+    outline: 2px solid var(--ad-gold);
+    outline-offset: 2px;
+  }
+  .archive-dig .card a:focus-visible,
+  .archive-dig .card summary:focus-visible {
+    outline-color: var(--ad-primary);
+  }
 
-      /* ---------- masthead (dark anchor) ---------- */
-      .mast {
-        padding: 58px 0 38px;
-      }
-      .eyebrow {
-        font-family: var(--mono);
-        font-size: 0.72rem;
-        letter-spacing: 0.22em;
-        text-transform: uppercase;
-        color: var(--gold);
-        margin: 0 0 14px;
-      }
-      h1 {
-        font-family: var(--sans);
-        font-weight: 700;
-        font-size: clamp(2.1rem, 5.5vw, 3.3rem);
-        line-height: 1.06;
-        margin: 0 0 18px;
-        color: #ffffff;
-      }
-      .lede {
-        max-width: 64ch;
-        font-size: 1.1rem;
-        margin: 0 0 30px;
-      }
-      .lede strong {
-        color: #ffffff;
-        font-weight: 700;
-      }
+  /* ---------- masthead ---------- */
+  .archive-dig .ad-mast {
+    padding: 58px 0 38px;
+  }
+  .archive-dig .ad-eyebrow {
+    font-family: var(--ad-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ad-gold);
+    margin: 0 0 14px;
+  }
+  .archive-dig h1 {
+    font-family: var(--ad-sans);
+    font-weight: 700;
+    font-size: clamp(2.1rem, 5.5vw, 3.3rem);
+    line-height: 1.06;
+    margin: 0 0 18px;
+    color: #ffffff;
+  }
+  .archive-dig .ad-lede {
+    max-width: 64ch;
+    font-size: 1.1rem;
+    margin: 0 0 30px;
+    color: var(--ad-on-dark);
+  }
+  .archive-dig .ad-lede strong {
+    color: #ffffff;
+    font-weight: 700;
+  }
+  .archive-dig .ad-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .archive-dig .stat {
+    background: var(--ad-glass);
+    border: 1px solid var(--ad-glass-line);
+    border-radius: 6px;
+    padding: 10px 16px 8px;
+    min-width: 122px;
+  }
+  .archive-dig .stat .n {
+    font-family: var(--ad-mono);
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: #ffffff;
+  }
+  .archive-dig .stat.top .n {
+    color: var(--ad-gold);
+  }
+  .archive-dig .stat .l {
+    font-family: var(--ad-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ad-on-dark-faint);
+    margin-top: 2px;
+  }
 
-      /* glass stat plates */
-      .stats {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
-      }
-      .stat {
-        background: var(--glass);
-        border: 1px solid var(--glass-line);
-        border-radius: 6px;
-        padding: 10px 16px 8px;
-        min-width: 122px;
-      }
-      .stat .n {
-        font-family: var(--mono);
-        font-size: 1.45rem;
-        font-weight: 700;
-        color: #ffffff;
-      }
-      .stat.top .n {
-        color: var(--gold);
-      }
-      .stat .l {
-        font-family: var(--mono);
-        font-size: 0.6rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: var(--on-dark-faint);
-        margin-top: 2px;
-      }
+  /* ---------- lessons ---------- */
+  .archive-dig .ad-lessons {
+    padding: 32px 0 4px;
+  }
+  .archive-dig .ad-lessons-head {
+    font-family: var(--ad-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ad-on-dark-faint);
+    margin: 0 0 4px;
+  }
+  .archive-dig .ad-lessons-sub {
+    margin: 0 0 16px;
+    font-size: 0.98rem;
+    font-style: italic;
+    color: var(--ad-on-dark);
+  }
+  .archive-dig .ad-lessons-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+  }
+  .archive-dig .lesson {
+    background: var(--ad-glass);
+    border: 1px solid var(--ad-glass-line);
+    border-left: 2px solid var(--ad-gold);
+    border-radius: 4px;
+    padding: 12px 14px;
+  }
+  .archive-dig .lesson h3 {
+    font-family: var(--ad-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #ffffff;
+    margin: 0 0 6px;
+  }
+  .archive-dig .lesson p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--ad-on-dark);
+  }
 
-      /* ---------- lessons strip ---------- */
-      .lessons {
-        padding: 32px 0 4px;
-      }
-      .lessons-head {
-        font-family: var(--mono);
-        font-size: 0.72rem;
-        letter-spacing: 0.2em;
-        text-transform: uppercase;
-        color: var(--on-dark-faint);
-        margin: 0 0 4px;
-      }
-      .lessons-sub {
-        margin: 0 0 16px;
-        font-size: 0.98rem;
-        font-style: italic;
-        color: var(--on-dark);
-      }
-      .lessons-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 10px;
-      }
-      .lesson {
-        background: var(--glass);
-        border: 1px solid var(--glass-line);
-        border-left: 2px solid var(--gold);
-        border-radius: 4px;
-        padding: 12px 14px;
-      }
-      .lesson h3 {
-        font-family: var(--mono);
-        font-size: 0.68rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: #ffffff;
-        margin: 0 0 6px;
-      }
-      .lesson p {
-        margin: 0;
-        font-size: 0.9rem;
-        color: var(--on-dark);
-      }
+  /* ---------- drawer rail ---------- */
+  .archive-dig .ad-controls {
+    position: sticky;
+    top: var(--ad-header-offset);
+    z-index: 5;
+    background: rgba(6, 17, 33, 0.72);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--ad-glass-line);
+    margin-top: 28px;
+  }
+  .archive-dig .ad-controls-inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 8px;
+    padding-top: 12px;
+  }
+  .archive-dig .ad-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--ad-glass);
+    border: 1px solid var(--ad-glass-line);
+    border-radius: 6px;
+    padding: 7px 12px;
+    margin-bottom: 10px;
+    flex: 1 1 240px;
+    max-width: 340px;
+  }
+  .archive-dig .ad-search svg {
+    width: 14px;
+    height: 14px;
+    stroke: var(--ad-on-dark-faint);
+    fill: none;
+    stroke-width: 2;
+    flex: none;
+  }
+  .archive-dig .ad-search input {
+    border: 0;
+    background: transparent;
+    font-family: var(--ad-mono);
+    font-size: 0.85rem;
+    color: #ffffff;
+    width: 100%;
+  }
+  .archive-dig .ad-search input::placeholder {
+    color: var(--ad-on-dark-faint);
+  }
+  .archive-dig .ad-search input:focus {
+    outline: none;
+  }
+  .archive-dig .ad-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 4px;
+    margin-left: auto;
+  }
+  .archive-dig .ad-tab {
+    font-family: var(--ad-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border: 1px solid var(--ad-glass-line);
+    border-bottom: 0;
+    border-radius: 6px 6px 0 0;
+    background: var(--ad-glass);
+    color: var(--ad-on-dark);
+    padding: 7px 12px 6px;
+    cursor: pointer;
+    transition: all 0.25s var(--ad-ease);
+  }
+  .archive-dig .ad-tab .ct {
+    color: var(--ad-on-dark-faint);
+    margin-left: 3px;
+  }
+  .archive-dig .ad-tab:hover {
+    background: rgba(255, 255, 255, 0.12);
+    transform: translateY(-2px);
+  }
+  .archive-dig .ad-tab[aria-pressed="true"] {
+    background: var(--ad-card);
+    color: var(--ad-primary);
+    font-weight: 700;
+    border-color: var(--ad-card);
+    padding-top: 10px;
+    padding-bottom: 8px;
+    transform: none;
+  }
+  .archive-dig .ad-tab[aria-pressed="true"] .ct {
+    color: var(--ad-ink-soft);
+  }
 
-      /* ---------- drawer rail: search + folder tabs (glass) ---------- */
-      .controls {
-        position: sticky;
-        top: 0;
-        z-index: 5;
-        background: rgba(6, 17, 33, 0.72);
-        backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
-        border-bottom: 1px solid var(--glass-line);
-        margin-top: 28px;
-      }
-      .controls-inner {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: flex-end;
-        gap: 8px;
-        padding-top: 12px;
-      }
-      .search {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        background: var(--glass);
-        border: 1px solid var(--glass-line);
-        border-radius: 6px;
-        padding: 7px 12px;
-        margin-bottom: 10px;
-        flex: 1 1 240px;
-        max-width: 340px;
-      }
-      .search svg {
-        width: 14px;
-        height: 14px;
-        stroke: var(--on-dark-faint);
-        fill: none;
-        stroke-width: 2;
-        flex: none;
-      }
-      .search input {
-        border: 0;
-        background: transparent;
-        font-family: var(--mono);
-        font-size: 0.85rem;
-        color: #ffffff;
-        width: 100%;
-      }
-      .search input::placeholder {
-        color: var(--on-dark-faint);
-      }
-      .search input:focus {
-        outline: none;
-      }
-      .tabs {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: flex-end;
-        gap: 4px;
-        margin-left: auto;
-      }
-      .tab {
-        font-family: var(--mono);
-        font-size: 0.68rem;
-        letter-spacing: 0.1em;
-        text-transform: uppercase;
-        border: 1px solid var(--glass-line);
-        border-bottom: 0;
-        border-radius: 6px 6px 0 0;
-        background: var(--glass);
-        color: var(--on-dark);
-        padding: 7px 12px 6px;
-        cursor: pointer;
-        transition: all 0.25s var(--ease);
-      }
-      .tab .ct {
-        color: var(--on-dark-faint);
-        margin-left: 3px;
-      }
-      .tab:hover {
-        background: rgba(255, 255, 255, 0.12);
-        transform: translateY(-2px);
-      }
-      .tab[aria-pressed="true"] {
-        background: var(--card);
-        color: var(--primary);
-        font-weight: 700;
-        border-color: var(--card);
-        padding-top: 10px;
-        padding-bottom: 8px;
-        transform: none;
-      }
-      .tab[aria-pressed="true"] .ct {
-        color: var(--ink-soft);
-      }
+  /* ---------- groups + cards ---------- */
+  .archive-dig .ad-cards {
+    padding: 36px 20px 44px;
+  }
+  .archive-dig .group {
+    margin-bottom: 40px;
+  }
+  .archive-dig .group-head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .archive-dig .group-head h2 {
+    font-family: var(--ad-sans);
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: #ffffff;
+    margin: 0;
+  }
+  .archive-dig .gcount {
+    font-family: var(--ad-mono);
+    font-size: 0.78rem;
+    color: var(--ad-on-dark-faint);
+  }
+  .archive-dig .group-sub {
+    margin: 4px 0 20px;
+    font-size: 0.98rem;
+    font-style: italic;
+    color: var(--ad-on-dark);
+  }
+  .archive-dig .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 24px 16px;
+  }
+  .archive-dig .card {
+    position: relative;
+    background: var(--ad-card);
+    color: var(--ad-ink);
+    border-radius: 2px 8px 8px 8px;
+    box-shadow: var(--ad-shadow);
+    margin-top: 14px;
+    transition: all 0.25s var(--ad-ease);
+  }
+  .archive-dig .card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--ad-shadow-hover);
+  }
+  .archive-dig .folder-tab {
+    position: absolute;
+    top: -14px;
+    left: 0;
+    max-width: 75%;
+    background: var(--ad-card-2);
+    border: 1px solid var(--ad-card-line);
+    border-bottom: 0;
+    border-radius: 6px 6px 0 0;
+    font-family: var(--ad-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ad-ink-soft);
+    padding: 3px 12px 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .archive-dig .card-body {
+    padding: 16px 16px 14px;
+  }
+  .archive-dig .card-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .archive-dig .repo {
+    font-family: var(--ad-sans);
+    font-weight: 700;
+    font-size: 1.14rem;
+    color: var(--ad-primary);
+    text-decoration: none;
+    border-bottom: 1px solid var(--ad-card-line);
+    overflow-wrap: anywhere;
+    transition: all 0.25s var(--ad-ease);
+  }
+  .archive-dig a.repo:hover {
+    border-bottom-color: var(--ad-gold);
+    color: var(--ad-primary);
+  }
+  .archive-dig .stamp {
+    flex: none;
+    font-family: var(--ad-mono);
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border: 2px solid;
+    border-radius: 3px;
+    padding: 3px 7px 2px;
+    transform: rotate(-4deg);
+    opacity: 0.9;
+    white-space: nowrap;
+  }
+  .archive-dig .t-top .stamp {
+    color: var(--ad-stamp-top);
+    border-color: var(--ad-stamp-top);
+  }
+  .archive-dig .t-active .stamp {
+    color: var(--ad-stamp-active);
+    border-color: var(--ad-stamp-active);
+  }
+  .archive-dig .t-superseded {
+    background: var(--ad-card-2);
+  }
+  .archive-dig .t-superseded .stamp {
+    color: var(--ad-ink-soft);
+    border-color: var(--ad-ink-soft);
+  }
+  .archive-dig .sup-note {
+    margin: 0 0 12px;
+    font-size: 0.88rem;
+    background: #eef0f2;
+    border-left: 2px solid var(--ad-ink-soft);
+    border-radius: 2px;
+    padding: 8px 10px;
+  }
+  .archive-dig .sup-note .k,
+  .archive-dig .go-note .k {
+    display: block;
+    font-family: var(--ad-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ad-ink-soft);
+    margin-bottom: 2px;
+  }
+  .archive-dig .sup-note a,
+  .archive-dig .go-note a {
+    color: var(--ad-primary);
+  }
+  .archive-dig .go-note {
+    margin: 0 0 12px;
+    font-size: 0.88rem;
+    background: rgba(238, 192, 94, 0.14);
+    border-left: 2px solid var(--ad-gold);
+    border-radius: 2px;
+    padding: 8px 10px;
+  }
+  .archive-dig .go-note .k {
+    color: #7a5b12;
+  }
+  .archive-dig .note-when {
+    display: block;
+    margin-top: 6px;
+    font-family: var(--ad-mono);
+    font-size: 0.56rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ad-ink-soft);
+    opacity: 0.8;
+  }
+  .archive-dig .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 10px;
+    margin: 8px 0 10px;
+    font-family: var(--ad-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ad-ink-soft);
+  }
+  .archive-dig .meta-row .arch {
+    color: #9c3d10;
+  }
+  .archive-dig .meta-row .incub {
+    color: #7a5b12;
+    font-weight: 700;
+  }
+  .archive-dig .one {
+    margin: 0 0 12px;
+    font-size: 0.97rem;
+  }
+  .archive-dig .filelinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    margin: 0 0 12px;
+    font-family: var(--ad-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .archive-dig .filelinks a {
+    color: var(--ad-primary);
+    text-decoration: none;
+    transition: all 0.25s var(--ad-ease);
+  }
+  .archive-dig .filelinks a:hover {
+    color: #7a5b12;
+    transform: translateX(3px);
+  }
+  .archive-dig details {
+    border-top: 1px dashed var(--ad-card-line);
+    padding-top: 8px;
+  }
+  .archive-dig summary {
+    cursor: pointer;
+    list-style: none;
+    font-family: var(--ad-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ad-primary);
+  }
+  .archive-dig summary::-webkit-details-marker {
+    display: none;
+  }
+  .archive-dig summary .caret {
+    display: inline-block;
+    transition: transform 0.25s var(--ad-ease);
+    margin-right: 5px;
+  }
+  .archive-dig details[open] summary .caret {
+    transform: rotate(90deg);
+  }
+  .archive-dig .detail-block {
+    padding-top: 10px;
+  }
+  .archive-dig .row {
+    margin-bottom: 10px;
+    font-size: 0.9rem;
+  }
+  .archive-dig .row .k {
+    display: block;
+    font-family: var(--ad-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ad-ink-soft);
+    margin-bottom: 2px;
+  }
+  .archive-dig .row.pitch {
+    background: var(--ad-card-2);
+    border-left: 2px solid var(--ad-gold);
+    padding: 8px 10px;
+    border-radius: 2px;
+  }
+  .archive-dig .detail-meta .tag {
+    display: inline-block;
+    font-family: var(--ad-mono);
+    font-size: 0.62rem;
+    color: var(--ad-ink-soft);
+    border: 1px solid var(--ad-card-line);
+    border-radius: 3px;
+    padding: 2px 7px;
+  }
+  .archive-dig .propose-card {
+    border: 2px dashed var(--ad-glass-line);
+    border-radius: 8px;
+    background: var(--ad-glass);
+    color: var(--ad-on-dark);
+    padding: 26px 24px;
+    max-width: 620px;
+  }
+  .archive-dig .propose-card h3 {
+    font-family: var(--ad-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin: 0 0 10px;
+    color: #ffffff;
+  }
+  .archive-dig .propose-card p {
+    margin: 0 0 16px;
+  }
+  .archive-dig .propose-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .archive-dig .propose-actions a {
+    font-family: var(--ad-mono);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--ad-vessel);
+    background: var(--ad-gold);
+    border-radius: 6px;
+    padding: 10px 15px;
+    transition: all 0.25s var(--ad-ease);
+  }
+  .archive-dig .propose-actions a:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 16px rgba(238, 192, 94, 0.25);
+    color: var(--ad-vessel);
+  }
+  .archive-dig .ad-empty {
+    display: none;
+    font-style: italic;
+    padding: 30px 20px;
+    color: var(--ad-on-dark-faint);
+  }
 
-      /* ---------- groups + folder cards (light reading surfaces) ---------- */
-      main {
-        padding: 36px 20px 44px;
-      }
-      .group {
-        margin-bottom: 40px;
-      }
-      .group-head {
-        display: flex;
-        align-items: baseline;
-        gap: 10px;
-      }
-      .group-head h2 {
-        font-family: var(--sans);
-        font-weight: 700;
-        font-size: 1.25rem;
-        color: #ffffff;
-        margin: 0;
-      }
-      .gcount {
-        font-family: var(--mono);
-        font-size: 0.78rem;
-        color: var(--on-dark-faint);
-      }
-      .group-sub {
-        margin: 4px 0 20px;
-        font-size: 0.98rem;
-        font-style: italic;
-        color: var(--on-dark);
-      }
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-        gap: 24px 16px;
-      }
+  /* ---------- method section ---------- */
+  .archive-dig .ad-method {
+    border-top: 1px solid var(--ad-glass-line);
+    padding: 30px 0 42px;
+    font-size: 0.9rem;
+    color: var(--ad-on-dark-faint);
+  }
+  .archive-dig .ad-method p {
+    max-width: 76ch;
+  }
+  .archive-dig .ad-method a {
+    color: var(--ad-on-dark);
+    transition: color 0.25s var(--ad-ease);
+  }
+  .archive-dig .ad-method a:hover {
+    color: var(--ad-gold);
+  }
+  .archive-dig .ad-method strong {
+    color: var(--ad-on-dark);
+    font-family: var(--ad-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
 
-      .card {
-        position: relative;
-        background: var(--card);
-        color: var(--ink);
-        border-radius: 2px 8px 8px 8px;
-        box-shadow: var(--card-shadow);
-        margin-top: 14px;
-        transition: all 0.25s var(--ease);
-      }
-      .card:hover {
-        transform: translateY(-4px);
-        box-shadow: var(--card-shadow-hover);
-      }
-      /* folder tab */
-      .folder-tab {
-        position: absolute;
-        top: -14px;
-        left: 0;
-        max-width: 75%;
-        background: var(--card-2);
-        border: 1px solid var(--card-line);
-        border-bottom: 0;
-        border-radius: 6px 6px 0 0;
-        font-family: var(--mono);
-        font-size: 0.6rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: var(--ink-soft);
-        padding: 3px 12px 2px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .card-body {
-        padding: 16px 16px 14px;
-      }
-      .card-top {
-        display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        gap: 10px;
-      }
-      .repo {
-        font-family: var(--sans);
-        font-weight: 700;
-        font-size: 1.14rem;
-        color: var(--primary);
-        text-decoration: none;
-        border-bottom: 1px solid var(--card-line);
-        overflow-wrap: anywhere;
-        transition: all 0.25s var(--ease);
-      }
-      a.repo:hover {
-        border-bottom-color: var(--gold);
-      }
-      .stamp {
-        flex: none;
-        font-family: var(--mono);
-        font-size: 0.58rem;
-        font-weight: 700;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        border: 2px solid;
-        border-radius: 3px;
-        padding: 3px 7px 2px;
-        transform: rotate(-4deg);
-        opacity: 0.9;
-        white-space: nowrap;
-      }
-      .t-top .stamp {
-        color: var(--stamp-top);
-        border-color: var(--stamp-top);
-      }
-      .t-active .stamp {
-        color: var(--stamp-active);
-        border-color: var(--stamp-active);
-      }
-      .t-superseded {
-        background: var(--card-2);
-      }
-      .t-superseded .stamp {
-        color: var(--ink-soft);
-        border-color: var(--ink-soft);
-      }
-      .sup-note {
-        margin: 0 0 12px;
-        font-size: 0.88rem;
-        background: #eef0f2;
-        border-left: 2px solid var(--ink-soft);
-        border-radius: 2px;
-        padding: 8px 10px;
-      }
-      .sup-note .k {
-        display: block;
-        font-family: var(--mono);
-        font-size: 0.6rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: var(--ink-soft);
-        margin-bottom: 2px;
-      }
-      .sup-note a {
-        color: var(--primary);
-      }
-      .go-note {
-        margin: 0 0 12px;
-        font-size: 0.88rem;
-        background: rgba(238, 192, 94, 0.14);
-        border-left: 2px solid var(--gold);
-        border-radius: 2px;
-        padding: 8px 10px;
-      }
-      .go-note .k {
-        display: block;
-        font-family: var(--mono);
-        font-size: 0.6rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: #7a5b12;
-        margin-bottom: 2px;
-      }
-      .go-note a {
-        color: var(--primary);
-      }
-      .note-when {
-        display: block;
-        margin-top: 6px;
-        font-family: var(--mono);
-        font-size: 0.56rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: var(--ink-soft);
-        opacity: 0.8;
-      }
-      .meta-row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px 10px;
-        margin: 8px 0 10px;
-        font-family: var(--mono);
-        font-size: 0.62rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--ink-soft);
-      }
-      .meta-row .incub {
-        color: #7a5b12;
-        font-weight: 700;
-      }
-      .meta-row .arch {
-        color: #9c3d10;
-      }
-      .one {
-        margin: 0 0 12px;
-        font-size: 0.97rem;
-      }
-      .filelinks {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px 16px;
-        margin: 0 0 12px;
-        font-family: var(--mono);
-        font-size: 0.68rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-      }
-      .filelinks a {
-        color: var(--primary);
-        text-decoration: none;
-        transition: all 0.25s var(--ease);
-      }
-      .filelinks a:hover {
-        color: #7a5b12;
-        transform: translateX(3px);
-      }
-      details {
-        border-top: 1px dashed var(--card-line);
-        padding-top: 8px;
-      }
-      summary {
-        cursor: pointer;
-        list-style: none;
-        font-family: var(--mono);
-        font-size: 0.68rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: var(--primary);
-      }
-      summary::-webkit-details-marker {
-        display: none;
-      }
-      summary .caret {
-        display: inline-block;
-        transition: transform 0.25s var(--ease);
-        margin-right: 5px;
-      }
-      details[open] summary .caret {
-        transform: rotate(90deg);
-      }
-      .detail-block {
-        padding-top: 10px;
-      }
-      .row {
-        margin-bottom: 10px;
-        font-size: 0.9rem;
-      }
-      .row .k {
-        display: block;
-        font-family: var(--mono);
-        font-size: 0.6rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: var(--ink-soft);
-        margin-bottom: 2px;
-      }
-      .row.pitch {
-        background: var(--card-2);
-        border-left: 2px solid var(--gold);
-        padding: 8px 10px;
-        border-radius: 2px;
-      }
-      .detail-meta .tag {
-        display: inline-block;
-        font-family: var(--mono);
-        font-size: 0.62rem;
-        color: var(--ink-soft);
-        border: 1px solid var(--card-line);
-        border-radius: 3px;
-        padding: 2px 7px;
-      }
+  @media (max-width: 560px) {
+    .archive-dig .stamp {
+      transform: none;
+    }
+    .archive-dig .ad-tabs {
+      margin-left: 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .archive-dig .card,
+    .archive-dig .ad-tab,
+    .archive-dig .repo,
+    .archive-dig .filelinks a,
+    .archive-dig summary .caret,
+    .archive-dig .propose-actions a,
+    .archive-dig .ad-method a {
+      transition: none;
+    }
+    .archive-dig .card:hover,
+    .archive-dig .ad-tab:hover,
+    .archive-dig .filelinks a:hover,
+    .archive-dig .propose-actions a:hover {
+      transform: none;
+    }
+  }
+</style>
 
-      /* proposed drawer CTA (glass, gold action) */
-      .propose-card {
-        border: 2px dashed var(--glass-line);
-        border-radius: 8px;
-        background: var(--glass);
-        color: var(--on-dark);
-        padding: 26px 24px;
-        max-width: 620px;
-      }
-      .propose-card h3 {
-        font-family: var(--mono);
-        font-size: 0.78rem;
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        margin: 0 0 10px;
-        color: #ffffff;
-      }
-      .propose-card p {
-        margin: 0 0 16px;
-      }
-      .propose-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
-      }
-      .propose-actions a {
-        font-family: var(--mono);
-        font-size: 0.72rem;
-        font-weight: 700;
-        letter-spacing: 0.1em;
-        text-transform: uppercase;
-        text-decoration: none;
-        color: var(--vessel);
-        background: var(--gold);
-        border-radius: 6px;
-        padding: 10px 15px;
-        transition: all 0.25s var(--ease);
-      }
-      .propose-actions a:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 6px 16px rgba(238, 192, 94, 0.25);
-      }
-
-      .empty {
-        display: none;
-        font-style: italic;
-        padding: 30px 20px;
-        color: var(--on-dark-faint);
-      }
-
-      /* ---------- footer (dark anchor) ---------- */
-      footer {
-        border-top: 1px solid var(--glass-line);
-        padding: 30px 0 42px;
-        font-size: 0.9rem;
-        color: var(--on-dark-faint);
-      }
-      footer p {
-        max-width: 76ch;
-      }
-      footer a {
-        color: var(--on-dark);
-        transition: color 0.25s var(--ease);
-      }
-      footer a:hover {
-        color: var(--gold);
-      }
-      footer strong {
-        color: var(--on-dark);
-        font-family: var(--mono);
-        font-size: 0.7rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-      }
-
-      @media (max-width: 560px) {
-        .stamp {
-          transform: none;
-        }
-        .tabs {
-          margin-left: 0;
-        }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        html {
-          scroll-behavior: auto;
-        }
-        .card,
-        .tab,
-        .repo,
-        .filelinks a,
-        summary .caret,
-        .propose-actions a,
-        footer a {
-          transition: none;
-        }
-        .card:hover,
-        .tab:hover,
-        .filelinks a:hover,
-        .propose-actions a:hover {
-          transform: none;
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <header class="mast">
-      <div class="wrap">
-        <p class="eyebrow">Civic Tech DC &middot; Archive Dig</p>
-        <h1>Ideas Graveyard</h1>
-        <p class="lede">
-          Thirteen years of Code&nbsp;for&nbsp;DC and Civic Tech DC left behind
-          nearly a hundred repositories. Most went quiet; some held genuinely
-          good ideas that ran out of runway. This is the records room:
-          <strong>files worth reviving</strong>,
-          <strong>projects alive right now</strong>, and
-          <strong>an empty drawer</strong> for the idea you haven't filed yet.
-        </p>
-        <div class="stats">
-          <div class="stat">
-            <div class="n" id="stat-all">–</div>
-            <div class="l">ideas on file</div>
-          </div>
-          <div class="stat top">
-            <div class="n" id="stat-top">–</div>
-            <div class="l">revival candidates</div>
-          </div>
-          <div class="stat">
-            <div class="n">2013&ndash;26</div>
-            <div class="l">years of history</div>
-          </div>
-          <div class="stat">
-            <div class="n" id="stat-active">–</div>
-            <div class="l">active today</div>
-          </div>
-          <div class="stat">
-            <div class="n">71</div>
-            <div class="l">repos archived</div>
-          </div>
+<div class="archive-dig" id="archive-dig-root">
+  <header class="ad-mast">
+    <div class="ad-wrap">
+      <p class="ad-eyebrow">Civic Tech DC &middot; Archive Dig</p>
+      <h1>Ideas Graveyard</h1>
+      <p class="ad-lede">
+        Thirteen years of Code&nbsp;for&nbsp;DC and Civic Tech DC left behind
+        nearly a hundred repositories. Most went quiet; some held genuinely good
+        ideas that ran out of runway. This is the records room:
+        <strong>files worth reviving</strong>,
+        <strong>projects alive right now</strong>, and
+        <strong>an empty drawer</strong> for the idea you haven't filed yet.
+      </p>
+      <div class="ad-stats">
+        <div class="stat">
+          <div class="n" id="stat-all">–</div>
+          <div class="l">ideas on file</div>
         </div>
-        <div class="lessons">
-          <p class="lessons-head">Why files end up here</p>
-          <p class="lessons-sub">
-            Four patterns from thirteen years of stalled repos. Read them before
-            you file a new idea.
-          </p>
-          <div class="lessons-grid">
-            <div class="lesson">
-              <h3>Tied to one cycle</h3>
-              <p>
-                Projects built for a single election, budget year, or event
-                stalled the day it passed. Design for the second cycle from day
-                one.
-              </p>
-            </div>
-            <div class="lesson">
-              <h3>Infra outlived the team</h3>
-              <p>
-                Self-hosted stacks rotted once the one person who ran them moved
-                on. Choose boring, cheap hosting.
-              </p>
-            </div>
-            <div class="lesson">
-              <h3>No path to the data</h3>
-              <p>
-                Projects that depended on a dataset or partner that never
-                materialized stayed prototypes. Secure the data source before
-                writing code.
-              </p>
-            </div>
-            <div class="lesson">
-              <h3>One maintainer deep</h3>
-              <p>
-                When the initiating volunteer left, the project followed.
-                Recruit a co-owner early, not after the first stall.
-              </p>
-            </div>
-          </div>
+        <div class="stat top">
+          <div class="n" id="stat-top">–</div>
+          <div class="l">revival candidates</div>
+        </div>
+        <div class="stat">
+          <div class="n">2013&ndash;26</div>
+          <div class="l">years of history</div>
+        </div>
+        <div class="stat">
+          <div class="n" id="stat-active">–</div>
+          <div class="l">active today</div>
+        </div>
+        <div class="stat">
+          <div class="n">71</div>
+          <div class="l">repos archived</div>
         </div>
       </div>
-    </header>
-
-    <div class="controls">
-      <div class="wrap controls-inner">
-        <label class="search">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="11" cy="11" r="7" />
-            <path d="M21 21l-4.3-4.3" />
-          </svg>
-          <input
-            id="q"
-            type="search"
-            placeholder="Search the files&hellip;"
-            aria-label="Search ideas"
-          />
-        </label>
-        <div class="tabs" id="chips">
-          <button class="tab" data-t="all" aria-pressed="true">
-            All <span class="ct"></span>
-          </button>
-          <button class="tab" data-t="top" aria-pressed="false">
-            Revive <span class="ct"></span>
-          </button>
-          <button class="tab" data-t="active" aria-pressed="false">
-            Active <span class="ct"></span>
-          </button>
-          <button class="tab" data-t="superseded" aria-pressed="false">
-            Superseded <span class="ct"></span>
-          </button>
-          <button class="tab" data-t="proposed" aria-pressed="false">
-            Proposed <span class="ct"></span>
-          </button>
+      <div class="ad-lessons">
+        <p class="ad-lessons-head">Why files end up here</p>
+        <p class="ad-lessons-sub">
+          Four patterns from thirteen years of stalled repos. Read them before
+          you file a new idea.
+        </p>
+        <div class="ad-lessons-grid">
+          <div class="lesson">
+            <h3>Tied to one cycle</h3>
+            <p>
+              Projects built for a single election, budget year, or event
+              stalled the day it passed. Design for the second cycle from day
+              one.
+            </p>
+          </div>
+          <div class="lesson">
+            <h3>Infra outlived the team</h3>
+            <p>
+              Self-hosted stacks rotted once the one person who ran them moved
+              on. Choose boring, cheap hosting.
+            </p>
+          </div>
+          <div class="lesson">
+            <h3>No path to the data</h3>
+            <p>
+              Projects that depended on a dataset or partner that never
+              materialized stayed prototypes. Secure the data source before
+              writing code.
+            </p>
+          </div>
+          <div class="lesson">
+            <h3>One maintainer deep</h3>
+            <p>
+              When the initiating volunteer left, the project followed. Recruit
+              a co-owner early, not after the first stall.
+            </p>
+          </div>
         </div>
       </div>
     </div>
+  </header>
 
-    <main class="wrap" id="main"></main>
-    <p class="empty wrap" id="empty">No files match that search.</p>
-
-    <footer>
-      <div class="wrap">
-        <p>
-          <strong>How this was made.</strong> On 24 July 2026, a swarm of 97 AI
-          agents (one per repo) read each repository's README and metadata and
-          scored the underlying idea 1&ndash;5 for revival potential. This is a
-          scouting report on <em>ideas</em>, not a code review &mdash; treat
-          every assessment as a lead to verify, not a verdict. Stall reasons are
-          inferred from repo evidence unless stated otherwise. In August 2026 a
-          web scan checked every dormant file against current official and
-          public tools; superseded files record what replaced them. This public
-          version is curated: private repositories, empty placeholders, mirrors
-          of external tools, and internal infrastructure repos are omitted from
-          the full scan.
-        </p>
-        <p>
-          <strong>Tiers.</strong> Revive files are dormant but worth a second
-          life. Active repos were pushed within the last year &mdash; join those
-          instead of starting fresh. Superseded files record what replaced them.
-        </p>
-        <p>
-          <strong>Filing a new idea.</strong> New proposals get added by the
-          organizers. Bring yours to a <a href="/events">project night</a> or
-          start a thread in <a href="/slack">Slack</a>, and if it finds legs it
-          gets a folder here with your name on it.
-        </p>
-        <p>
-          Repository names link to GitHub &middot;
-          <a href="https://github.com/civictechdc">github.com/civictechdc</a>
-        </p>
+  <div class="ad-controls">
+    <div class="ad-wrap ad-controls-inner">
+      <label class="ad-search">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="11" cy="11" r="7" />
+          <path d="M21 21l-4.3-4.3" />
+        </svg>
+        <input
+          id="ad-q"
+          type="search"
+          placeholder="Search the files&hellip;"
+          aria-label="Search ideas"
+        />
+      </label>
+      <div class="ad-tabs" id="ad-chips">
+        <button class="ad-tab" data-t="all" aria-pressed="true">
+          All <span class="ct"></span>
+        </button>
+        <button class="ad-tab" data-t="top" aria-pressed="false">
+          Revive <span class="ct"></span>
+        </button>
+        <button class="ad-tab" data-t="active" aria-pressed="false">
+          Active <span class="ct"></span>
+        </button>
+        <button class="ad-tab" data-t="superseded" aria-pressed="false">
+          Superseded <span class="ct"></span>
+        </button>
+        <button class="ad-tab" data-t="proposed" aria-pressed="false">
+          Proposed <span class="ct"></span>
+        </button>
       </div>
-    </footer>
-
-    <script>
-      const DATA = [
-        {
-          name: "adopt-a-hydrant",
-          url: "https://github.com/civictechdc/adopt-a-hydrant",
-          score: 4,
-          tier: "superseded",
-          supersededUrl:
-            "https://doc.arcgis.com/en/arcgis-solutions/latest/reference/introduction-to-adopt-a-hydrant.htm",
-          supersededName: "Esri Adopt-A-Hydrant",
-          superseded:
-            "Now a maintained Esri ArcGIS Solutions product, and Fairfax, Prince William, Montgomery, and WSSC all run programs. DC's gap is adopting a program, not building software.",
-          theme: "Org Infrastructure",
-          one: 'A Rails app letting DC residents "adopt" and claim responsibility for shoveling out a specific fire hydrant after snowstorms.',
-          problem:
-            "During heavy snow, fire hydrants get buried and firefighters waste critical time digging them out; crowdsourcing hydrant-shoveling to neighbors speeds response times.",
-          why: "Last pushed Jan 2013 with no further commits; likely a seasonal hack-day project (snow-specific) that lost maintainer attention once the CfA/CfDC fellowship cycle moved on and Rails 3/Ruby 1.9.3 stack aged out.",
-          pitch:
-            'The "adopt-a-civic-object" pattern (hydrants, storm drains, benches, little free libraries) is evergreen and this repo proves it shipped and ran; a modern revival could ditch the custom Rails app entirely for a lightweight map (Mapbox/Leaflet + open muni GIS hydrant data) plus SMS/app notifications timed to NWS snow alerts, making adoption and reminders near-zero-maintenance.',
-          maturity: "deployed",
-          tech: "Ruby on Rails 3.x + Postgres",
-          data: "none",
-          pushed: "2013-01-23",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "ancElectionHistory",
-          url: "https://github.com/civictechdc/ancElectionHistory",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://code.dccouncil.gov/us/dc/council/laws/24-342",
-          stillGoName: "D.C. Law 24-342",
-          stillGo:
-            "The portal D.C. Code 1-1001.05(a)(21) mandates is codified as Not Funded, and the FY27 budget released every other conditioned piece of Law 24-342 while leaving the data portal as the last one. DCBOE ships certified CSVs back to 2012 and OpenANC covers 2020-2024, but no official longitudinal view exists, and ANC-level turnout exists nowhere.",
-          theme: "Elections, ANC & Voting",
-          one: "A data pipeline and planned Shiny/web app to visualize historical trends in DC Advisory Neighborhood Commission (ANC) election results.",
-          problem:
-            "DC has ANCs (hyperlocal elected bodies) but no easy way to see historical trends: turnout, uncontested seats, incumbency, seat vacancies/turnover over time. Data existed only as scattered board-of-elections pages and a hard-to-parse historical PDF (1979-2012).",
-          why: "Appears to be a data-collection/cleaning phase that never advanced to the planned visualization app (Shiny) or public deployment; likely a hack-day/volunteer project that lost momentum after the initial scraping work, common for Code for DC projects without a dedicated ongoing maintainer.",
-          pitch:
-            "The portal mandated by D.C. Code 1-1001.05(a)(21) sits codified as Not Funded, which turns this project into either the pilot that shames the line item into a budget or the stopgap that serves residents meanwhile. DCBOE's certified CSVs (2012-2024) and OpenANC's 2020-2024 dataset with uncontested and margin fields mean the longitudinal ANC dashboard is mostly assembly work; ANC-level turnout needs precinct-to-SMD estimation nobody has attempted.",
-          maturity: "prototype",
-          tech: "R and Python (Jupyter notebooks), R Markdown",
-          data: "DC Board of Elections website (ANC election results, scraped), anc.dc.gov (current ANC membership), historical_commissioners.pdf (1979-2012)",
-          pushed: "2020-03-04",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "ancfinder",
-          url: "https://github.com/civictechdc/ancfinder",
-          site: "/projects/ANCFinder.html",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://openanc.org/",
-          supersededName: "OpenANC",
-          superseded:
-            "OANC's official commissioner lookup and the community-run OpenANC both cover this, current through 2026.",
-          theme: "Elections, ANC & Voting",
-          one: "A public website (ancfinder.org) that lets DC residents find their Advisory Neighborhood Commission (ANC), see commissioners, boundaries on a map, meeting info, and election candidates.",
-          problem:
-            "DC's 40+ ANCs and 300+ single-member districts are hyperlocal, low-visibility government bodies; residents have no easy way to find their ANC, their commissioner, meeting schedules, or election candidates.",
-          why: "Appears to have lost active maintainers after 2019; long-running volunteer hack-day project that likely outpaced available contributor bandwidth once core features were built (classic Code for DC project lifecycle).",
-          pitch:
-            "The core need (find your ANC, your commissioner, upcoming elections, meeting minutes) is still unmet and still hyperlocal-important; a rebuild could ditch the custom Django/Docker stack for a static site + modern DC GIS open data feeds and use an LLM to summarize meeting minutes/agendas automatically, turning a maintenance-heavy 2013-era app into a nearly zero-maintenance civic info tool.",
-          maturity: "deployed",
-          tech: "Python/Django (Docker, uWSGI, nginx, Mapbox)",
-          data: "DC government ANC/ward boundary data, Mapbox",
-          pushed: "2019-04-03",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "bus-ada",
-          url: "https://github.com/civictechdc/bus-ada",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://github.com/ProjectSidewalk/SidewalkWebpage",
-          stillGoName: "Project Sidewalk",
-          stillGo:
-            "DC's per-stop ADA data still dates to the 2016 transition-plan survey, DDOT's update effort is in its 2025 cycle, and Better Bus removed 527 stops in June 2025, so the official data is stale on the stop set itself. Project Sidewalk remains actively maintained, with 205,000 labels left from its dormant DC pilot.",
-          theme: "Transit & Mobility",
-          one: "A tool to remotely audit WMATA bus stop ADA compliance by overlaying a survey form on Google Street View imagery aimed at each stop.",
-          problem:
-            "Auditing physical ADA accessibility (curb ramps, sidewalk-to-curb connections, benches/shelters) at thousands of WMATA bus stops normally requires expensive in-person site visits by DDOT/WMATA staff.",
-          why: "One-day hackathon build (#innoMAYtion, May 2015); no commits after July 2015, no README or docs, Python 2 syntax (dict.has_key/iteritems) now broken, hardcoded/expired Google Maps API usage pattern (signed_in=true) — classic hack-day project that was never picked back up after the event ended.",
-          pitch:
-            "DC's authoritative per-stop ADA dataset was captured in 2016, DDOT's ADA transition plan is in its 2025 update cycle, and Better Bus eliminated 527 stops in June 2025, so the official inventory is stale on the stop set itself, not just condition. Project Sidewalk, actively maintained with 205,000 labels from its dormant DC pilot, is the identical crowdsourcing method: the ask is restarting DC coverage with a bus-stop label type, not building from scratch.",
-          maturity: "working",
-          tech: "Python 2 (GTFS processing) + vanilla JS/jQuery/Bootstrap 3 (Google Maps/Street View frontend)",
-          data: "WMATA GTFS feed (stops.txt, stop_times.txt) + Google Street View API",
-          pushed: "2015-07-25",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "campaign-finance-explorer",
-          url: "https://github.com/civictechdc/campaign-finance-explorer",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://efiling.ocf.dc.gov/",
-          stillGoName: "OCF e-filing portal",
-          stillGo:
-            "OCF now publishes the data: e-filing search, a contributions map, and CSV and XML bulk downloads. But analysis is left to the reader — no candidate comparison, donor pattern, or cycle-over-cycle dashboards exist, official or community. The data problem this project fought is solved; the dashboard it wanted to be is still unbuilt.",
-          theme: "Elections, ANC & Voting",
-          one: "An interactive visual explorer for DC political campaign contributions, letting users filter/compare donors and money flows by candidate and ward on a map.",
-          problem:
-            "DC campaign finance data (from the Office of Campaign Finance) is hard for ordinary citizens to explore — who's funding which candidates, by ward, by contribution size — without a visual, filterable tool.",
-          why: "Last pushed May 2017; likely reliant on a custom backend API (campaign-finance.codefordc.org) that has since gone dark, and built on an aging Keshif/jQuery/Leaflet stack from the mid-2010s Code for DC hack-day era — classic volunteer-project attrition once the original maintainers moved on.",
-          pitch:
-            "The Keshif-era visual explorer died with its custom API, but the concept, a filterable visual explorer of DC contributions by candidate, ward, and donor, now sits one static build away from OCF bulk exports. Pair it with dc-campaign-finance-watch: one modern build covers both cards.",
-          maturity: "deployed",
-          tech: "JavaScript (jQuery + D3 v4 + Keshif visualization framework + Leaflet 1.0)",
-          data: "DC campaign finance contribution records (via a custom codefordc.org API, likely sourced from DC OCF filings), plus a 2012 ward geojson for map overlay",
-          pushed: "2017-05-02",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "capital-improvement",
-          url: "https://github.com/civictechdc/capital-improvement",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://dcbudget.com/",
-          stillGoName: "dcbudget.com",
-          stillGo:
-            "The CIP still ships as PDF volumes, the CFO's interactive capital dashboard (cfoinfo.dc.gov) is offline entirely, and the quarterly Capital Financial Status Report tracks spend against lifetime authority but never how planned costs drift between CIP editions. That cross-edition join is the build.",
-          theme: "Budget & Spending",
-          one: "A searchable web explorer that scrapes DC's annual six-year Capital Improvement Plan (buildings/roads investment) out of locked PDF/XML files and lets residents track how project costs and timelines change year over year.",
-          problem:
-            "DC's capital improvement plans (multi-year budget for infrastructure like schools, roads, buildings) were published only in non-open, hard-to-parse formats, making it nearly impossible for residents to see how planned projects and their costs/timelines evolved over time.",
-          why: "Appears to be a Code for DC hack-project that got a working v1 shipped and iterated for about a month (June-July 2016), then lost momentum once the initial volunteer(s) moved on; no updates since, and the underlying data source/parsing likely needs re-scraping each year, which nobody kept doing.",
-          pitch:
-            "The gap narrowed but sharpened: the CFO's quarterly Capital Financial Status Report tracks project spend against lifetime budget authority, but nothing anywhere tracks how planned costs and schedules drift from one CIP edition to the next, and the CFO's old interactive dashboard is dead. dcbudget.com, a solo volunteer project, exports project-level JSON and Excel with each deployment; partner with it rather than rebuilding, and add the cross-edition join the official tools avoid.",
-          maturity: "deployed",
-          tech: "JavaScript (Gulp/Bower frontend) + Ruby ETL scraper",
-          data: "DC OCFO Capital Improvement Plan documents (PDF/XML), scraped via custom Ruby ETL",
-          pushed: "2016-07-20",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "CashBailApp",
-          url: "https://github.com/civictechdc/CashBailApp",
-          score: 4,
-          tier: "superseded",
-          supersededUrl:
-            "https://www.communityjusticeexchange.org/en/nbfn-directory",
-          supersededName: "National Bail Fund Network",
-          superseded:
-            "DC abolished cash bail in 1992, so there is no local use, and national bail funds run their own infrastructure. Congress could change this: H.R. 5214 passed the House in late 2025.",
-          theme: "Criminal Justice",
-          one: "A web app (Java/Spring Boot) built at a 2020 NYC Coders BLM Hackathon to connect people held on cash bail with community donors/advocates and local nonprofit bail funds.",
-          problem:
-            "Cash bail disproportionately jails poor and Black defendants who are legally presumed innocent simply because they can't pay; community bail funds exist but lack a platform to connect vetted cases with willing donors/advocates.",
-          why: "Likely a one-off hackathon project (built at NYC Coders BLM Hackathon, not originally a Civic Tech DC project) with no full-time maintainer after the event; last commit 2022, never deployed publicly, and it needed real nonprofit partners to operate that likely never materialized.",
-          pitch:
-            'Cash bail reform and community bail funds (e.g., The Bail Project, National Bail Fund Network) are still very active causes; a modern rebuild as a lightweight matching/crowdfunding platform (Next.js + Stripe/GiveButter integration, or just an LLM-assisted intake form for nonprofits to vet and publish cases) could plug directly into existing bail fund orgs\' workflows instead of trying to be its own system of record — the core "case marketplace connecting funders to vetted need" concept is sound and the hard part (nonprofit partnerships, vetting) was already the intended model here.',
-          maturity: "prototype",
-          tech: "Java 8 / Spring Boot / Thymeleaf / Bootstrap4 / Maven",
-          data: "none (self-contained app; would need to integrate with local nonprofit bail funds' data/workflows)",
-          pushed: "2022-06-21",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "cfsa-referral",
-          url: "https://github.com/civictechdc/cfsa-referral",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://211warmline.dc.gov/",
-          supersededName: "DC 211 Warmline",
-          superseded:
-            "The 211 Warmline (February 2025, CFSA's Office of Thriving Families with DBH) is a resident-facing referral hub, not a caseworker decision tree. But an internal CFSA routing tool cannot be built or adopted by outside volunteers, and the District now funds the hub that owns the service inventory it would need. Revisit only if CFSA initiates the ask.",
-          theme: "Social Services & Benefits",
-          one: "A React decision-tree app for CFSA caseworkers to answer yes/no questions in the field and get routed to the right voluntary child-welfare program.",
-          problem:
-            "DC CFSA caseworkers in the field had no simple tool to determine which of 6 voluntary programs (crisis stabilization, parent education, housing, substance-abuse referral, etc.) a client/family was eligible for — decisions relied on caseworker memory of scattered eligibility criteria.",
-          why: "Hackathon-born prototype that likely needed live FACES system integration and ongoing CFSA agency partnership/data-sharing to become production-usable; volunteer momentum ended ~Feb 2018 (last push) with wishlist items like FACES write-back and program enrollment never built.",
-          pitch:
-            "The core idea — a guided eligibility decision tree for a confusing multi-program benefits/referral system — is a durable, high-value civic-tech pattern (applies to CFSA today, plus any DC agency with overlapping voluntary programs). Reviving it now is much easier: an LLM could ingest the actual program eligibility rules/regs and generate/maintain the decision tree instead of hand-coding it, and a simple hosted form replaces the custom React app entirely. Real starting assets: the original decision-tree logic, 6 program definitions, and named CFSA stakeholders who could validate a rebuild if still reachable.",
-          maturity: "prototype",
-          tech: "React (Create React App) + Jest, deployed via Netlify, Docker/Travis CI setup",
-          data: "CFSA (DC Child and Family Services Agency) program eligibility criteria; FACES case management system (referenced, not integrated)",
-          pushed: "2018-02-22",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "chat-with-your-anc",
-          url: "https://github.com/civictechdc/chat-with-your-anc",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://oanc.dc.gov/",
-          stillGoName: "OANC minutes",
-          stillGo:
-            "The Office of ANCs posts minutes centrally for all 46 ANCs, FY24 through FY26, collected but uneven, with about a sixth as image-only scans. No cross-ANC full-text search exists; OANC's own site search cannot see inside the documents.",
-          theme: "Misc / Civic Data",
-          one: 'A proposed chatbot to let DC residents "chat with" their Advisory Neighborhood Commission (ANC) meeting minutes/records via LLM.',
-          problem:
-            "ANCs are DC's hyperlocal government bodies, but their meeting minutes are scattered, inconsistent PDFs/text dumps that residents never read, making it hard to track what's happening in local government (zoning, liquor licenses, development) at the neighborhood level.",
-          why: "Likely a hack-day idea where only the tedious data-collection step (manually gathering ANC1A minutes) got done before interest/time ran out; no LLM chat layer was ever built.",
-          pitch:
-            "The Office of ANCs solved collection: minutes for all 46 ANCs are centrally posted for FY24 through FY26, uniform in location if not in format, with about a sixth needing OCR. The build is exactly this idea's second half: full-text and retrieval-augmented search across the corpus, with citations back to the source minutes.",
-          maturity: "idea-only",
-          tech: "none (plain text data only, no code)",
-          data: "ANC1A meeting minutes (manually collected text files, 2021-2023)",
-          pushed: "2023-11-08",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "clean-slate",
-          url: "https://github.com/civictechdc/clean-slate",
-          site: "/projects/clean-slate.html",
-          score: 4,
-          tier: "top",
-          stillGo:
-            "Automatic relief is still phasing in, with courts given until October 2027 and a ten-year automatic tier, so motion-based relief (misdemeanor five years, felony eight from completion of sentence, plus actual innocence) is the near-term path, and no eligibility screener exists for it, official or otherwise.",
-          theme: "Criminal Justice",
-          one: "A guided-interview website that walks DC residents/attorneys through whether their criminal record is eligible to be sealed/expunged, with forms and attorney lookup tools.",
-          problem:
-            "DC legal clinics needed a fast way to determine if a client's criminal record qualifies for sealing/expungement, generate intake referrals, train new attorneys on the process, and give clients self-service guidance plus the actual court forms.",
-          why: "Last push Jan 2017; the README notes a hand-off to MissionLaunch's fork, and the eligibility logic was never maintained here after that.",
-          pitch:
-            "DC's Second Chance Amendment Act retires the original wizard, but automatic relief phases in slowly: courts have until October 2027, and the automatic tier requires ten years. The near-term need is an eligibility screener for motion-based relief, the misdemeanor five-year, felony eight-year (from completion of sentence), and actual-innocence paths. No official checker exists, and legal-aid intake is a form, not a screener.",
-          maturity: "deployed",
-          tech: "Static HTML/JS site with a JSON-driven rules/flow engine (no backend), bilingual (en/es)",
-          data: "DC criminal record sealing/expungement eligibility rules (statutory logic, e.g. § 48-904.01); combined-flow.json wizard tree",
-          pushed: "2017-01-27",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "dc-campaign-finance-watch",
-          url: "https://github.com/civictechdc/dc-campaign-finance-watch",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://efiling.ocf.dc.gov/",
-          stillGoName: "OCF e-filing portal",
-          stillGo:
-            "OCF now publishes the data: e-filing search, a contributions map, and CSV and XML bulk downloads. But analysis is left to the reader — no candidate comparison, donor pattern, or cycle-over-cycle dashboards exist, official or community. The data problem this project fought is solved; the dashboard it wanted to be is still unbuilt.",
-          theme: "Elections, ANC & Voting",
-          one: "A full-stack open API and web dashboard for exploring DC campaign contribution data, letting citizens compare candidates' fundraising side by side.",
-          problem:
-            "DC campaign finance data from the Office of Campaign Finance was historically opaque and hard to query or compare across candidates; this project aimed to expose it via an open API plus visualizations.",
-          why: "Long-running Code for DC hack-night project that got real sustained contributor effort over years but eventually lost active maintainers; likely stalled on OCF data-format changes/scraper rot and the burden of maintaining a Mongo+Docker stack with no dedicated owner.",
-          pitch:
-            "The original ran for years at campaign-finance.codefordc.org on scraped data and a Mongo stack. A rebuild is far cheaper now: OCF bulk CSV and XML feed a static pipeline directly, no scraper and no database. The unbuilt layer is the analytics — candidate comparisons, donor patterns, small-dollar versus PAC shares, cycle-over-cycle trends — with the 2026 races as the launch moment.",
-          maturity: "deployed",
-          tech: "Node.js/Express + MongoDB + React/Webpack, Dockerized",
-          data: "DC Office of Campaign Finance (ocf.dc.gov)",
-          pushed: "2022-12-06",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "dcps-budget",
-          url: "https://github.com/civictechdc/dcps-budget",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://dcpsbudget.com/",
-          supersededName: "dcpsbudget.com",
-          superseded:
-            "DCPS runs an official per-school budget site with worksheets, comparisons, and an archive back to SY22-23, four years of comparable data, enough for recent trend analysis.",
-          theme: "Budget & Spending",
-          one: "A public-facing interactive visualization of the DC Public Schools (DCPS) budget, built as a static-site data viz app with a Gulp/Bower/npm toolchain.",
-          problem:
-            'DC school budgets are notoriously opaque (per-pupil funding formulas, line items scattered across PDFs/Excel), making it hard for parents, teachers, and advocates (partnered with "Our DC Schools") to understand or scrutinize how DCPS money is allocated.',
-          why: "Appears to be a single-budget-cycle (FY16) project tied to that year's advocacy push; once the FY16 cycle closed there was no maintainer or funding to keep re-pointing it at new budget years, and it was never generalized into a reusable/data-refreshable tool.",
-          pitch:
-            "Budget transparency for DC schools is still a live pain point every budget season, and the interactive-visualization concept holds up well. A revival wouldn't need the old Gulp/Bower toolchain at all: pull DCPS budget data directly (many jurisdictions now publish machine-readable open-data budget feeds), rebuild the front end in a modern lightweight stack (e.g., static site + D3/Observable Plot), and use an LLM to auto-generate plain-language summaries of line-item changes year over year — turning a one-off FY16 snapshot into an always-current, self-updating budget explainer.",
-          maturity: "deployed",
-          tech: "HTML/JS (Gulp build, Bower dependencies)",
-          data: "DC Public Schools budget data (FY16 budget office)",
-          pushed: "2015-04-22",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "districthousing",
-          url: "https://github.com/civictechdc/districthousing",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://dhcd.dc.gov/page/housing-locator-services",
-          supersededName: "DC housing locator services",
-          superseded:
-            "Housing applications moved into official portals (DCHA's agency portal, the IZ lottery, DCHousingSearch). The real blocker for cross-program intake is consent and data-sharing, not PDF filling.",
-          theme: "Housing & Tenant Rights",
-          one: "A Rails app that lets caseworkers fill out one online intake form and auto-generates the multiple separate PDF applications needed for DC Section 8 housing programs.",
-          problem:
-            "DC housing caseworkers had to manually re-enter the same client data across multiple redundant paper/PDF Section 8 applications, wasting time and increasing error risk for a population that badly needs efficient help.",
-          why: "No commits since January 2018. The app depends on tooling that has since aged out (old Ruby, pdftk, Cloud9) and on agency-specific PDF forms that need updating as DC's housing forms change; nothing was kept current after the 2013-2018 Code for DC era.",
-          pitch:
-            "The \"one form, many auto-filled PDFs\" pattern is still exactly the right shape for benefits/housing intake, and it's much easier now: replace pdftk/pdf-forms gem plumbing with modern PDF-fill libraries or an LLM-assisted form-mapping layer, skip the Rails/Docker/Cloud9-era setup entirely with a lightweight serverless form + PDF-fill pipeline, and pair it with current DC Housing Authority forms; the caseworker pain point (redundant data entry across agency PDFs) hasn't gone away.",
-          maturity: "deployed",
-          tech: "Ruby on Rails (Docker, pdftk/pdf-forms gem)",
-          data: "none (uses local PDF form templates for DC housing agency applications)",
-          pushed: "2018-01-09",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "eligibility-blueprint",
-          url: "https://github.com/civictechdc/eligibility-blueprint",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://github.com/MyFriendBen/benefits-api",
-          supersededName: "MyFriendBen",
-          superseded:
-            "MyFriendBen on PolicyEngine is exactly this product: an open-source, white-label, multi-state benefits screener, funded and actively maintained.",
-          theme: "Social Services & Benefits",
-          one: "A generic React app that turns a spreadsheet of questions/answers/programs into a decision-tree eligibility screener webform",
-          problem:
-            "DC residents (starting with CFSA child/family services clients, later ERAP rental assistance applicants) needed a simple way to answer a few questions and find out which government assistance programs they qualify for, without a caseworker manually walking them through eligibility rules",
-          why: "Last pushed March 2018; appears to have been a hackathon/prototype-to-pilot project (grew out of codefordc/cfsa-referral) that got two real deployments but no ongoing maintainer or generalized productization after that — never expanded beyond CSV-driven config or got a real hosting/ops story.",
-          pitch:
-            "The core idea (spreadsheet-configurable decision-tree eligibility screener for benefits programs) is exactly the kind of thing govtech needs and is still built ad hoc today; reviving it with a modern no-code form builder, LLM-assisted rule extraction from program regulations, and a real hosting/admin UI instead of raw CSVs would make it dramatically easier to spin up new benefits screeners (SNAP, TANF, housing, ERAP-style emergency programs) for any jurisdiction.",
-          maturity: "working",
-          tech: "JavaScript / React (Create React App)",
-          data: "CFSA/ERAP eligibility CSVs (Google Sheets), configured via .env",
-          pushed: "2018-03-14",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "open211",
-          url: "https://github.com/civictechdc/open211",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://211warmline.dc.gov/",
-          supersededName: "DC 211 Warmline",
-          superseded:
-            "The directory need is served twice over, by the official DC 211 Warmline and findhelp. The remaining gap, no open API for the city's directory data, is procurement advocacy rather than code.",
-          theme: "Regulations & Legislation",
-          one: "An open, standardized API and website for DC's 211 human/social services directory, built on the Ohana API design so DC's out-of-date 211 data could be interoperable and commonly maintained.",
-          problem:
-            "DC lacked a single up-to-date, interoperable directory of health/human/social services, making it hard for people in need to find eligible resources, and prior resource-directory efforts kept dying because maintaining the data was too costly.",
-          why: "Classic hack-day fragmentation: the interesting logic (API, website, import script) was split across several external repos and Heroku apps rather than consolidated here, and once the initiating volunteers moved on (one went on to found the Open Referral standard itself) there was no maintainer left to keep DC's data pipeline running.",
-          pitch:
-            "The Open Referral / HSDS data standard this project pioneered on is now mature and widely adopted (2-1-1 orgs, HHS, many cities use it), and LLMs make the hardest original problem - normalizing messy, stale service-provider data and keeping it current - dramatically cheaper via scraping/entity resolution/nightly refresh agents; a revival could pull DC's current 211/Aunt Bertha-style data, publish it as an Open Referral-compliant API, and layer an LLM chat interface on top for eligibility matching.",
-          maturity: "prototype",
-          tech: "Ruby (data import script) + static HTML/CSS front end; API built on Ohana API (Node/Rails-family human-services API spec)",
-          data: "DC 211 community resource data (Ohana API spec / Open Referral)",
-          pushed: "2016-02-01",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "rent-stabilization",
-          url: "https://github.com/civictechdc/rent-stabilization",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://rentregistry.dc.gov/",
-          stillGoName: "DC RentRegistry",
-          stillGo:
-            "The November 2025 re-registration deadline filled the registry, now 19,582 registrations covering roughly 194,000 units in free bulk CSVs refreshed daily. Coverage chasing is over; what is missing is the analytics layer, compliance and rent-adjustment views, plus public surfacing of the monthly reports section 42-3502.03c already requires of DHCD.",
-          theme: "Housing & Tenant Rights",
-          one: "A data pipeline to infer which DC rental units are subject to rent stabilization (rent control) and model the effect of policy changes, since no direct public dataset says which units are covered.",
-          problem:
-            "DC's rent control law exempts many units (post-1976 buildings, small landlords with ≤4 units, voluntary agreements, etc.) but there is no public list of which specific units/buildings are actually rent-controlled, making the law's real coverage and the impact of proposed changes (e.g., moving the exemption cutoff from 1976 to 1986) impossible to assess without inference from property records.",
-          why: "Analysis reached a first-pass conclusion (e.g., ~48% of DC housing units are in buildings with 4-or-fewer units), but the visualization was explicitly marked work-in-progress using simulated (not real) data, and commits stopped in March 2017 after final analysis tweaks. No technical blocker is evident; the repo doesn't record why work ended.",
-          pitch:
-            "DHCD's rent registry launched in June 2025 with free bulk CSV exports refreshed daily, and the November re-registration deadline filled it: 19,582 registrations covering roughly 194,000 units. The build is no longer chasing registrations. It is the analytics layer the registry still lacks: compliance views, rent-adjustment tracking, and surfacing the monthly section 42-3502.03c reports DHCD owes the Council.",
-          maturity: "working",
-          tech: "R and Python (data wrangling/analysis scripts), Shiny (visualization demo)",
-          data: "DC Open Data (CAMA residential/condo/commercial property assessment datasets), ACS, HUD PHA inventory, CPI-W",
-          pushed: "2017-03-16",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "rfj_expungement",
-          url: "https://github.com/civictechdc/rfj_expungement",
-          score: 4,
-          tier: "top",
-          stillGoUrl: "https://www.risingforjustice.org/",
-          stillGoName: "Rising for Justice",
-          stillGo:
-            "Rising for Justice still determines eligibility manually by phone and email intake, and no rules-as-code exists for the amended DC statute. Worth checking Code for America's DC policy-design work for reusable artifacts before building.",
-          theme: "Criminal Justice",
-          one: "A Next.js web form that encodes Rising for Justice's legal logic to help pro bono attorneys determine whether a DC client's criminal record is eligible for expungement.",
-          problem:
-            "Pro bono lawyers at legal clinics need to quickly and correctly evaluate whether a client's DC criminal record qualifies for expungement/sealing — the underlying law is a complex, jurisdiction-specific decision tree that's easy to get wrong manually.",
-          why: "Unclear — development stopped abruptly in January 2023 after a long active run (97 merged PRs), which reads more like an engagement winding down than an idea failing. The repo doesn't record why.",
-          pitch:
-            "Rising for Justice still determines expungement eligibility manually by phone and email intake. The 2025 statute rewrite invalidated this repo's decision logic but shrank the build to something tractable: rules-as-code for D.C. Code sections 16-801 through 16-806 as amended. Rasa Legal proves the model commercially in three other states, and Code for America's DC policy-design work is worth mining for artifacts before building.",
-          maturity: "working",
-          tech: "JavaScript/TypeScript, Next.js, Jest, CircleCI",
-          data: "none (encodes RFJ's internal legal eligibility rules, no external dataset)",
-          pushed: "2023-01-04",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "rfk-community",
-          url: "https://github.com/civictechdc/rfk-community",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://ourrfk.dc.gov/",
-          supersededName: "OurRFK",
-          superseded:
-            "Overtaken by events: the stadium deal was approved and the District ran its own master-plan engagement; the site's future is decided.",
-          theme: "Misc / Civic Data",
-          one: "A civic engagement tool built with DC Councilmember Charles Allen's office to collect resident input on redeveloping the 170-acre former RFK stadium site in Ward 7.",
-          problem:
-            "DC residents had no accessible, structured way to weigh in on redevelopment plans for a major public land parcel (former RFK stadium, NPS-owned, leased to DC through 2038) as legislation moved to transfer the land to DC government control.",
-          why: "Unclear — commits grew sporadic after the initial 2019 survey push and stopped in April 2023. The repo doesn't record a formal wrap-up.",
-          pitch:
-            "The pattern — partner directly with a council office to run a structured public-input survey on a live land-use decision, with results visualized back to the community — is a reusable civic-tech template, not just a one-off. Today this could be rebuilt fast with a lightweight form (Typeform/Google Forms as they already used), LLM-based thematic coding of open-ended comments instead of manual review, and a public results dashboard, dramatically cutting the Django/React build cost the original team paid for.",
-          maturity: "working",
-          tech: "Django + React.js",
-          data: "Google Forms survey embedded in site; DC Council/NPS land data (implied)",
-          pushed: "2023-04-21",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "ballot-initiative-dashboard",
-          url: "https://github.com/civictechdc/ballot-initiative-dashboard",
-          score: 3,
-          tier: "top",
-          stillGoUrl: "https://www.dcboe.org/",
-          stillGoName: "DCBOE",
-          stillGo:
-            "DCBOE still publishes measures as titles plus loose PDFs, with its own eight-step pipeline documented but never rendered as per-measure status with signature clocks. Only the foie gras measure is certified for November 2026; the wage and rent-freeze initiatives missed the July deadline and target 2027, the cycle this build should aim at.",
-          theme: "Elections, ANC & Voting",
-          one: "A proposed dashboard to track future/upcoming DC ballot initiatives",
-          problem:
-            "DC residents and civic groups have no easy way to track ballot initiatives that are being proposed or gathering signatures before they reach the ballot, making it hard to engage early or plan advocacy.",
-          why: "Never got past the initial scaffolding/data-gathering stage; abandoned after one month with no code written, likely a hack-day idea that lost momentum",
-          pitch:
-            "DCBOE's current-measures page lists every measure as a title plus loose PDFs, with no status pipeline, signature clocks, or machine-readable export, and Ballotpedia only loosely tracks certification. The wage and rent-freeze initiatives that missed the July 2026 deadline are aiming at 2027; a structured tracker of DCBOE's own eight-step pipeline, shipped before that cycle heats up, is a small, high-visibility build.",
-          maturity: "idea-only",
-          tech: "None (no code committed; primaryLanguage null)",
-          data: "Likely DC Board of Elections ballot initiative filings (unconfirmed, no code exists to verify)",
-          pushed: "2023-03-15",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "baltimore-lunch",
-          url: "https://github.com/civictechdc/baltimore-lunch",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://cityservices.baltimorecity.gov/summerfood/",
-          supersededName: "Baltimore summer food",
-          superseded:
-            "Official tools run live every season at three levels: USDA's site finder, Maryland MSDE's search, and Baltimore City's own map, with SUN Bucks reducing the need further.",
-          theme: "Social Services & Benefits",
-          one: "A geolocation map app pinpointing free summer lunch locations for Baltimore students.",
-          problem:
-            "Low-income students who rely on free/reduced school lunch lose that food access over summer break; USDA/city summer meal programs exist but families often don't know where sites are.",
-          why: "Classic single-weekend hackathon project (Code for DC/Baltimore 2015) — built, deployed, and shipped for one event, then abandoned once the hack day ended; no maintainer continued it.",
-          pitch:
-            "The core idea (find-a-free-meal-site map) is still needed every summer in every city and is now much easier: USDA publishes a public Summer Meals site-locator API/dataset, so a modern version could pull live official data instead of crowdsourced GitHub issues, and be built as a lightweight static map (Mapbox/Leaflet + GeoJSON) deployable in a day with an LLM doing the data cleanup/geocoding.",
-          maturity: "deployed",
-          tech: "CSS/JS front-end (Bower + Gulp build)",
-          data: "Baltimore summer free-lunch site locations (crowdsourced via GitHub issues)",
-          pushed: "2015-04-29",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "bikeshare-odds",
-          url: "https://github.com/civictechdc/bikeshare-odds",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://capitalbikeshare.com/bike-angels",
-          supersededName: "Bike Angels",
-          superseded:
-            "Superseded sideways: no maintained tool forecasts CaBi availability, and fifteen years of abandoned prototypes is the demand signal. Real-time status is commoditized across the major apps, and Lyft's Bike Angels rebalances scarcity with rider incentives instead of predictions. Skip unless a specific underserved corridor shows up.",
-          theme: "Transit & Mobility",
-          one: "A Leaflet.js map of DC Capital Bikeshare stations showing the odds of finding an available bike based on historical dock data.",
-          problem:
-            "Bikeshare riders can't tell, at a glance, how likely a given station is to have an available bike (or open dock) at a given time — leading to wasted trips to empty/full stations.",
-          why: "Likely a single-hack-day project that reached a working demo but wasn't maintained past March 2014 — no further commits, no community adoption.",
-          pitch:
-            "The core visualization idea (probability-of-availability heatmap by station and time) is still genuinely useful for bikeshare/scooter riders and is now much easier to build: Capital Bikeshare publishes live GBFS feeds and historical trip data directly, so a modern version could use real-time + ML-based short-term forecasting instead of static historical averages, and ship as a lightweight PWA with push notifications for favorite stations.",
-          maturity: "deployed",
-          tech: "JavaScript/Leaflet.js (client-side, static HTML/CSS/JS)",
-          data: "Capital Bikeshare dock history (opendatadc.org, via DSSG)",
-          pushed: "2014-03-19",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "capital-nature-ingest",
-          url: "https://github.com/civictechdc/capital-nature-ingest",
-          score: 3,
-          tier: "superseded",
-          superseded:
-            "Capital Nature curates its own events calendar now, with dozens of listings maintained through the current season.",
-          theme: "Misc / Civic Data",
-          one: "A scraper pipeline that pulls nature/outdoor events from dozens of DC-area sources (NPS, Eventbrite, park/nature orgs) and feeds them into the Capital Nature events calendar.",
-          problem:
-            "DC has many scattered nature and outdoor event sources (parks, NPS, nonprofits, Eventbrite listings) with no unified calendar; Capital Nature (a 501c3) needed an automated way to aggregate them into one events calendar for area residents.",
-          why: "No commits since Oct 2021. The per-source scraper model (each event source needs its own scraper, per the README's contributing section) is a heavy ongoing maintenance burden for a volunteer project.",
-          pitch:
-            'The concept (aggregate fragmented local event sources into one calendar) is evergreen and now much cheaper to execute: LLM-based extraction can replace bespoke per-source scrapers (the original repo\'s issue tracker was literally "one scraper per event source needs writing/maintaining" - a maintenance nightmare an LLM scraper/parser can generalize away), and a small serverless function + cheap hosting removes the CDK/Lambda complexity. Worth reviving as a general-purpose "local events aggregator" template usable beyond nature/DC.',
-          maturity: "deployed",
-          tech: "Python 3.6 (scrapers), AWS Lambda/CDK, Docker",
-          data: "Web scraping of NPS API, Eventbrite API, and DC-area nature/outdoor org event pages",
-          pushed: "2021-10-14",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "communityresources",
-          url: "https://github.com/civictechdc/communityresources",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://211warmline.dc.gov/",
-          supersededName: "DC 211 Warmline",
-          superseded:
-            "The directory need is served twice over, by the official DC 211 Warmline and findhelp. The remaining gap, no open API for the city's directory data, is procurement advocacy rather than code.",
-          theme: "Social Services & Benefits",
-          one: 'A static web front-end (index.html + JS/CSS) for browsing DC community/social-service resource data, hosted at communityresourcedata.codefordc.org, formerly branded "DC Open 211".',
-          problem:
-            "Surface DC's scattered social/community service resources (the kind of info 211 hotlines provide - food, housing, health, benefits referrals) in a searchable/browsable web format, likely for residents or caseworkers to find help services more easily than through DC's official 211 system.",
-          why: "Looks like a single-person/small hack-day build that hit a data-maintenance wall (a directory of resources needs ongoing curation) and a technical stumble (last commit's confession of possibly breaking the page); no further commits after April 2014, likely abandoned as interest/volunteer time moved on.",
-          pitch:
-            "The core idea - a clean, always-current directory of DC social services (food banks, shelters, benefits offices, health clinics) - is still needed; DC 211 and similar directories are notoriously stale. A revival could pull from modern open data (DC.gov open data portal, 211Search/AWS 211 API, 2-1-1 Metro DC feeds) and use an LLM to normalize/dedupe listings and auto-flag stale entries, something infeasible to hand-maintain in 2014 but cheap now.",
-          maturity: "deployed",
-          tech: "Static HTML/CSS/JS (no backend evident)",
-          data: "DC 211 / community resource data (unclear original source), 2013-2014",
-          pushed: "2014-04-09",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "curiouscity",
-          url: "https://github.com/civictechdc/curiouscity",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://51st.news/",
-          supersededName: "The 51st",
-          superseded:
-            "The 51st, the worker-run successor to DCist, runs reader-question journalism for DC.",
-          theme: "Misc / Civic Data",
-          one: "A Rails web app letting residents submit and vote on questions about their city, with selected questions investigated and answered by journalists/reporters.",
-          problem:
-            "Community members have questions about how their city works but no structured channel to surface which questions matter most to residents or get them answered by journalists/investigators.",
-          why: "Unclear — appears to be a Code for DC fork/adaptation of an existing Chicago-based (WBEZ Curious City) concept; likely a single hack event that wasn't continued once the initial build was done (only 5 commits, all from early 2015).",
-          pitch:
-            "The crowdsourced-investigative-journalism-question model (à la WBEZ's original Curious City) is still compelling for local newsrooms or civic orgs wanting community-driven accountability journalism; a modern rebuild could ditch the custom Rails admin/voting stack for a lightweight Next.js + Postgres app, use LLMs to auto-cluster/dedupe submitted questions and draft initial research briefs for reporters, and skip Disqus entirely in favor of native threaded comments.",
-          maturity: "working",
-          tech: "Ruby on Rails 4.0",
-          data: "none",
-          pushed: "2015-01-04",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "DC-Budget-Sankey",
-          url: "https://github.com/civictechdc/DC-Budget-Sankey",
-          score: 3,
-          tier: "top",
-          stillGoUrl: "https://www.dccouncilbudget.com/analytics",
-          stillGoName: "Council budget lookup",
-          stillGo:
-            "This repo's own demo once ran and died along with its data source (cfoinfo.dc.gov), so no flow visualization of the DC budget exists today, while structured data to feed one finally does.",
-          theme: "Budget & Spending",
-          one: "A Sankey diagram visualizing how DC's budget funds flow into specific government agencies.",
-          problem:
-            "DC's budget is published as opaque tabular financial data; ordinary residents can't see at a glance where tax dollars actually go by agency/fund.",
-          why: "Single hack-day/hackathon-style project (created Oct 2015, last commit Feb 2016 plus an automated civic.json spec-update PR merged later); no ongoing maintainer, no license file (flagged by the bot PR), budget data was hardcoded/manually converted so it would go stale every fiscal year without upkeep.",
-          pitch:
-            "This repo's demo once ran and died with its cfoinfo.dc.gov data source. No flow visualization of the DC budget exists today, and the niche is unclaimed: rebuild the Sankey on dcbudget.com's structured exports and the Council lookup tool's data instead of hand-converted PDFs.",
-          maturity: "working",
-          tech: "JavaScript (D3.js-style Sankey), static site on GitHub Pages",
-          data: "DC CFO budget/finance data (cfoinfo.dc.gov)",
-          pushed: "2016-02-01",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "dc-council-chat",
-          url: "https://github.com/civictechdc/dc-council-chat",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://dccouncil.gov/hearings/",
-          supersededName: "Council hearings",
-          superseded:
-            "Council streams are plentiful and official, and YouTube's native live chat on the Committee of the Whole stream covers the co-watching layer.",
-          theme: "Misc / Civic Data",
-          one: "A site to watch DC Council meetings live and chat about them alongside other civically-engaged viewers.",
-          problem:
-            "DC Council meetings are long, low-production-value government livestreams that few residents watch or understand; there was no companion layer for real-time public commentary/context while a meeting is happening.",
-          why: 'Classic hack-day churn: pivoted backend mid-project (scraper -> Horizon rewrite that discarded prior work per "removing all previous" commit), then went dark after ~2 months with no chat UI or scraper actually shipped in the final state — likely lost momentum after the hackathon ended and RethinkDB Horizon itself was discontinued by its maker shortly after (2016), stranding the chosen stack.',
-          pitch:
-            "The idea (co-viewing + chat layered on government livestreams, like Twitch chat for local legislature) is still fresh and now much easier: DC Council streams are on YouTube/Granicus with timestamps, and an LLM could auto-summarize agenda items, tag speakers, and surface relevant bill/vote context in the chat in real time, turning idle chatter into an annotated public record. Modern tooling (Supabase/Firebase realtime or Durable Objects for the chat backend, a serverless scraper for the meeting calendar, and an LLM co-pilot for live context) would let one person rebuild this in a weekend instead of standing up self-hosted RethinkDB Horizon.",
-          maturity: "prototype",
-          tech: "JavaScript (RethinkDB Horizon backend, Docker Compose dev environment)",
-          data: "DC Council meeting calendar (via scraper)",
-          pushed: "2016-08-07",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "dc_bus_stuff",
-          url: "https://github.com/civictechdc/dc_bus_stuff",
-          score: 3,
-          tier: "top",
-          stillGo:
-            "DDOT's bus-lane layer is twelve unlisted segments with no install dates, WMATA reports bus performance at system and line level only, and the public join is a single roll-up figure (13 percent faster since 2019). Boston's TransitMatters proves stop-pair transit analysis in production; nobody has built the DC lane-by-lane version.",
-          theme: "Transit & Mobility",
-          one: "A 2019 Code for DC repo exploring DC bus GPS/bustime data to evaluate bus infrastructure, starting with the H Street bus lane pilot.",
-          problem:
-            "DC transit riders and planners lack accessible tools to evaluate whether bus infrastructure interventions (like dedicated bus lanes) actually improve reliability, or to identify where buses are slow/unreliable and where new interventions are needed.",
-          why: "Looks like a single hack-night/hack-day exploration that got one round of real analysis (H Street pilot) done, then the more ambitious ideas (camera counting, bus-stop quality score) were never picked up; no commits after Sept 2019, likely lost momentum after the initial volunteer(s) moved on.",
-          pitch:
-            "Still nobody's build: DDOT publishes a thin bus-lane layer, WMATA publishes system- and line-level performance, and the only public join is WMATA's single roll-up that priority segments run 13 percent faster since 2019. Boston's TransitMatters dashboard proves stop-pair transit analysis in production. A lane-by-lane bus priority scorecard, with install dates reconstructed from DDOT project pages, remains the most novel local build in this archive.",
-          maturity: "prototype",
-          tech: "Jupyter Notebook / Python",
-          data: "WMATA bustime GPS archive (via markongithub/bus_data_archive) + WMATA GTFS/developer APIs",
-          pushed: "2019-09-12",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "dcfinancials",
-          url: "https://github.com/civictechdc/dcfinancials",
-          score: 3,
-          tier: "top",
-          stillGoUrl: "https://dcbudget.com/",
-          stillGoName: "dcbudget.com",
-          stillGo:
-            "DC has no open checkbook, just single-payment lookup, per-year purchase-order snapshots, and agency dashboards. dcbudget.com's structured exports cover one fiscal year at a time; the missing layer is multi-year analysis stitched across editions, which no tool attempts.",
-          theme: "Budget & Spending",
-          one: "A 2013 Code for DC hack project to parse DC government budget and spending data (agency POs, CBE contracts) into structured CSV/JSON for eventual analysis and visualization.",
-          problem:
-            "DC government budget and spending data (purchase orders, contract/vendor data, CBE certifications) was locked in inconsistent spreadsheets/PDFs, making it hard for the public or watchdogs to analyze how DC spends money or track certified business enterprise contracting.",
-          why: "Classic hack-day project: got as far as writing data parsers and exporting CSVs from raw spreadsheets, but never built the promised analysis/visualization layer and was abandoned after initial data-wrangling burst (no commits after June 2013).",
-          pitch:
-            "The parsing this repo attempted is now largely solved by dcbudget.com's structured per-deployment exports, and DC still has no open checkbook, only single-payment lookup and per-year purchase-order snapshots. What survives of the idea is the analysis layer: multi-year spending trends and cost tracking stitched across budget editions, which neither dcbudget.com, a single-year snapshot, nor any official tool attempts.",
-          maturity: "prototype",
-          tech: "JavaScript (parsing scripts) + raw Excel/CSV data files",
-          data: "DC Open Data (data.dc.gov) - DCFPI budget spreadsheets, CBE (Certified Business Enterprise) contract/PO data",
-          pushed: "2013-06-01",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "ERDA",
-          url: "https://github.com/civictechdc/ERDA",
-          score: 3,
-          tier: "top",
-          stillGoUrl: "https://fems.dc.gov/",
-          stillGoName: "FEMS",
-          stillGo:
-            "FEMS' neighborhood response-time maps are static FY2022 snapshots on a 300-meter grid, the performance page tops out at the FY24 plan, and OUC's 911 dashboard measures call answering, not unit arrival. The equity question, which blocks wait longest, is four years stale in official channels.",
-          theme: "Public Safety",
-          one: "A 2014 Code for DC project to statistically analyze DC's emergency response (fire/EMS dispatch) data and expose it via an API for visualizations.",
-          problem:
-            "DC's emergency response (911/EMS/fire) data was hard to access and analyze; the project wanted to clean, merge, and expose it so the public/researchers could understand response times and patterns.",
-          why: "A single hack-season project (2014) that lost momentum after the initial volunteer group moved on; reopened in 2026 when verification showed the official response-time products had gone stale.",
-          pitch:
-            "The Excel-sanitization era this repo fought is over, but the official replacements went stale: response-time equity analysis needs incident-level dispatch data joined to neighborhoods, and nothing current is published. A refreshed dashboard would be the only current view in the city. Confirm the incident-level data source on Open Data DC before building; if it has to come from FOIA, that is where this project stalls.",
-          maturity: "working",
-          tech: "Python (data cleaning scripts) + a separate API layer, published via GitHub Pages",
-          data: "DC emergency response (fire/EMS) dispatch data, sourced from DC government + Google Drive raw/preprocessed exports",
-          pushed: "2014-08-19",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "hospital-pricing",
-          url: "https://github.com/civictechdc/hospital-pricing",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://hospitalpricingfiles.org/",
-          supersededName: "Hospital pricing files",
-          superseded:
-            "Price-file aggregation is commodity now: Turquoise Health's free patient tool, PatientRightsAdvocate's file library, and Sage Transparency all cover it.",
-          theme: "Public Health",
-          one: "A bare data repository for manually collecting and standardizing DC-area hospital chargemaster/price-transparency files.",
-          problem:
-            "Hospital pricing is opaque and hard for patients/consumers to compare; standard charge files exist per-hospital but weren't aggregated or normalized anywhere in one place for DC.",
-          why: "Manual file collection is tedious and doesn't scale; no processing/normalization code was ever written to make the raw files useful, and the effort predates (by ~2 years) the federal price-transparency mandate that would have made this systematic.",
-          pitch:
-            "The core idea (aggregate and normalize hospital chargemaster data so patients/researchers can compare prices) is now federally mandated data (CMS hospital price transparency rule, effective 2021, requires standardized machine-readable files) so the hard part of getting hospitals to disclose has been solved by regulation - reviving this would mean writing a scraper/ETL pipeline against the now-standardized CMS files plus an LLM-assisted schema normalizer to handle inconsistent hospital formats, then a simple comparison UI; much more tractable in 2026 than manually downloading XLS/PDF files by hand.",
-          maturity: "idea-only",
-          tech: "None (data-only repo; raw CSV/XLS/XLSX/PDF/TSV files, no code)",
-          data: "Manually collected hospital billing/price transparency files (CSV/XLS/PDF) from individual DC-area hospitals",
-          pushed: "2019-01-29",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "LegiTrack",
-          url: "https://github.com/civictechdc/LegiTrack",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://lims.dccouncil.gov/",
-          supersededName: "LIMS",
-          superseded:
-            "The Council's LIMS covers bills and member voting records back to 1989, updated daily, with a public API.",
-          theme: "Regulations & Legislation",
-          one: "A front-end tracker for DC Council bills and council-member votes, built as a Middleman/Ruby static site.",
-          problem:
-            "DC residents have no easy way to see what bills the DC Council is considering or how council members voted on them.",
-          why: "Classic hack-day project — appears to be a single weekend/short sprint effort (5 commits, one month of activity) that never got backend/data integration, deployment, or user features finished before being abandoned.",
-          pitch:
-            "The core idea — a clean, searchable \"how did my council member vote\" tracker — is still exactly what DC civic engagement needs and there's still no great public tool for it. Today this is far easier: DC Council's own LIMS/legislative data plus an LLM to summarize bill text and generate plain-language vote explainers could turn this from a static hack-day mockup into a real living site in a weekend, hosted free on Vercel/Cloudflare Pages.",
-          maturity: "prototype",
-          tech: "Ruby (Middleman static site generator) + CSS/JS",
-          data: "DC Council legislative data (bills/votes) — source unspecified in README",
-          pushed: "2016-02-02",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "opendatadc",
-          url: "https://github.com/civictechdc/opendatadc",
-          site: "/projects/opendatadc.html",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://opendata.dc.gov/",
-          supersededName: "Open Data DC",
-          superseded:
-            "The official portal serves the catalog role. The remaining gap, roughly a quarter of non-sensitive datasets unpublished, is an advocacy fight, not a rebuild.",
-          theme: "Regulations & Legislation",
-          one: "A community-run open data portal (data.codefordc.org) built on CKAN, intended as a broader/complementary alternative to the DC government's official Open Data DC portal.",
-          problem:
-            "DC lacked an independent, broader-scope open data hub not bound by government data-collection mandates — a place for volunteer-curated datasets, analysis, and teaching resources for residents/researchers who want data the official DC government portal doesn't carry or present well.",
-          why: "Unclear — likely maintainer bandwidth/CKAN operational overhead; CKAN deployments are heavy (docker-compose stack with Solr, Postgres, nginx, datapusher) for a volunteer org to sustain long-term, and DC government's own Open Data DC portal likely reduced the unique value proposition over time.",
-          pitch:
-            'The CKAN-hosting-and-curation model is now much easier to run cheaply (managed CKAN hosting, or swap to a lightweight modern stack like Datasette/DuckDB + static site, and use LLMs to auto-generate dataset descriptions/etl scripts). The real reusable idea is the "three streams" volunteer structure (portal, analysis, stakeholder-matching) plus the ANC-level turnout-estimation R work already in the repo — a modern revival could rebuild it as a lightweight Datasette-based portal with LLM-assisted data cleaning/cataloging, resurrecting the civic-analysis pipeline (e.g., ANC turnout, precinct data) with far less infra overhead than CKAN required.',
-          maturity: "deployed",
-          tech: "JavaScript/Python (CKAN extension) with R analysis scripts (Shiny app)",
-          data: "DC Open Data portal (CKAN), plus ad-hoc datasets from DC govt and other sources",
-          pushed: "2020-02-19",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "school-modernization",
-          url: "https://github.com/civictechdc/school-modernization",
-          score: 3,
-          tier: "top",
-          stillGoUrl:
-            "https://edscape.dc.gov/page/dcps-public-school-facility-modernizations",
-          stillGoName: "Edscape map",
-          stillGo:
-            "DME's Edscape map shows which schools are modernized and when, but publishes no dollar amounts, so the equity-spending question remains unanswerable. The dollars exist in CIP PDFs and dcbudget.com's export; the join is the whole build.",
-          theme: "Budget & Spending",
-          one: "A data viz project mapping 15 years (~$5B) of DCPS school facilities modernization spending by school/neighborhood to reveal equity gaps in fund distribution",
-          problem:
-            "DCPS ran a ~15-year, ~$5B facilities modernization program; spending data existed but wasn't legible, making it hard to tell whether upgrades were distributed equitably across neighborhoods/schools ahead of council budget hearings",
-          why: "Likely a volunteer project tied to a specific public-hearing timeline; once that legislative moment passed, momentum and maintenance stopped (last push July 2016).",
-          pitch:
-            "DME's official Edscape map now shows which schools are modernized and when, through FY31, and even publishes the ward-equity framing. But it shows no dollar amounts, so the original equity-spending question is still unanswerable. The remaining build is joining CIP cost data to the official map's timeline.",
-          maturity: "prototype",
-          tech: "HTML/JS (d3.js) with R data-processing scripts",
-          data: "DCPS/PCSB/OSSE/OCFO facilities spending data (input/output CSVs in repo)",
-          pushed: "2016-07-21",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "the-rat-hack",
-          url: "https://github.com/civictechdc/the-rat-hack",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://dchealth.dc.gov/rodent-control-dashboard",
-          supersededName: "Rodent Control Dashboard",
-          superseded:
-            "DC Health launched an official rodent-control dashboard in July 2026: complaint hotspots, seasonal trends, ward-level treatment counts.",
-          theme: "Public Health",
-          one: "A 2017-18 Code for DC hack project analyzing DC 311 rodent-complaint data to predict rat outbreak trends and feed a public 311 data portal.",
-          problem:
-            'DC was ranked among the "rattiest" cities in America; the city wanted to predict rodent-complaint upticks in space/time to support Mayor Bowser\'s "Rat Riddance" initiative and complement OCTO\'s own modeling.',
-          why: 'Typical hack-day project: activity concentrated in 2017-2018 (feature engineering PRs), then went quiet after April 2018 pushdate; no further commits, likely lost momentum after initial contributors moved on and no clear "deployed" outcome documented in this repo.',
-          pitch:
-            "DC 311 data is now far richer and easier to pull (Open Data DC APIs), and modern time-series/spatial libraries (or an LLM-assisted feature pipeline) make the predictive modeling this project attempted in R trivial to redo in Python with a proper dashboard (e.g. a lightweight geospatial heatmap + trend forecast) instead of a Docker+RStudio onboarding flow.",
-          maturity: "prototype",
-          tech: "R (RStudio/Docker), companion 311 data portal (separate repo/site)",
-          data: "DC 311 service request data (OCTO); Dropbox export",
-          pushed: "2018-04-12",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "us-congress-pizza-flag-tracker",
-          url: "https://github.com/civictechdc/us-congress-pizza-flag-tracker",
-          score: 3,
-          tier: "superseded",
-          supersededUrl:
-            "https://www.aoc.gov/what-we-do/programs-ceremonies/capitol-flag-program",
-          supersededName: "Capitol Flag Program",
-          superseded:
-            "The House runs its own system: FlagTrack at flagorder.house.gov (staff-facing), with FlagTrack 2.0 funded in March 2026 to add constituent-facing tracking across order, fly, shipping, and delivery dates. An outside tracker would duplicate a funded official build with no data access.",
-          theme: "Org Infrastructure",
-          one: "A tracker for the U.S. Capitol's flag-flying request/fulfillment process, built with congressional staff (Modernization Staff Association) to manage constituent flag orders.",
-          problem:
-            "Congressional offices field constituent requests to have a flag flown over the U.S. Capitol (a common constituent-service perk); tracking and fulfilling these requests was apparently a manual/ad-hoc process this tool aimed to systematize with an order-management workflow (statuses like archived/cancelled/uncancelled).",
-          why: "unclear — no commits since Oct 2022; likely lost core volunteers post-pandemic Code for DC wind-down rather than any technical failure, since the project was clearly functional and had staff buy-in.",
-          pitch:
-            "A working order-management tool for a real, recurring congressional constituent-service workflow, built with an actual congressional staff partner (Modernization Staff Association), is rare in civic tech — most projects never land a government partner. If flag requests are still handled manually in some offices, this could be revived as a lightweight internal tool; modern form-intake tooling and LLM-assisted status tracking could replace much of the custom React frontend.",
-          maturity: "deployed",
-          tech: "Python/Flask backend + React/TypeScript frontend, Postgres/SQLite",
-          data: "none (manual/staff-submitted flag order data)",
-          pushed: "2022-10-12",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "congressional-tech",
-          url: "https://github.com/civictechdc/congressional-tech",
-          site: "/projects/congressional-tech.html",
-          score: 5,
-          tier: "active",
-          theme: "Regulations & Legislation",
-          one: "A portfolio/monorepo of civic-tech tools to make congressional operations and data (hearings, committee video, appropriations, CRS/GAO reports, schedules) more accessible and efficient, several with AI-powered analysis.",
-          problem:
-            "Congressional data and operations (hearing/markup records, committee YouTube archives, appropriations documents, CRS/GAO reports, floor schedules, job postings) are scattered, unstructured, and hard for staff, journalists, and the public to use; the repo catalogs ~18 discrete tool ideas across accessibility, workflow efficiency, AI content enhancement, and predictive analytics for legislative data.",
-          why: 'Not stalled -- actively maintained as of Feb 2026 with ongoing commits and multiple contributors; some sub-projects within the portfolio (predictive/analytical tools in section IV) remain unscoped ("not set" level of effort) and unbuilt.',
-          pitch:
-            'This is not stalled -- it\'s a live, well-organized backlog of congressional-tech ideas already prioritized by level of effort, with a working monorepo and active contributors. Anyone wanting to "revive" an idea here should instead just pick up one of the un-started items directly from the project list (e.g. Bill Delay Tracker, Witness Database with testimony summarization, CRS/GAO report AI transformation) -- modern LLMs make the AI-heavy items (newsletter generation, transcript summarization, report transformation) far more tractable now than when first scoped.',
-          maturity: "deployed",
-          tech: "TypeScript (Next.js) + Python monorepo (turborepo, devcontainer)",
-          data: "Congress.gov, committee YouTube channels, CRS/GAO reports, GovTrack",
-          pushed: "2026-02-08",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "DMVWaterWatch",
-          url: "https://github.com/civictechdc/DMVWaterWatch",
-          site: "/projects/watervoice-dmv.html",
-          score: 5,
-          tier: "active",
-          theme: "Environment & Energy",
-          one: 'A mobile-first map giving paddlers, rowers, and swimmers a traffic-light "is it safe to get in the water today" report card for ~34 inner-DMV recreation sites.',
-          problem:
-            'Water-quality/safety data for DMV rivers (bacterial sampling, streamflow, rainfall, impairment status) is real but scattered across PDFs, dashboards, and dormant Water Reporter embeds, with no single consumer-facing answer to "can I safely paddle/swim here today."',
-          why: "Not stalled — a young project with continuous progress; the open items are external (data-partner outreach, API tokens, legal review) rather than signs of abandonment.",
-          pitch:
-            "This isn't really a graveyard candidate yet — it's an actively developed, well-architected MVP (real APIs wired, tested grading rubric, deploy-ready) that just needs the remaining outreach/access items (Swim Guide token, DOEE EQuIS access, legal review) and a Cloudflare Pages deploy to go live. If it stalls, the highest-value revival move is simply finishing Phase 6: get the two remaining data partnerships and ship it, since the hard engineering work (connector architecture, grading logic, UI, tests) is already done.",
-          maturity: "working",
-          tech: "TypeScript / Next.js 16 + React 19 + MapLibre",
-          data: "USGS NWIS, USGS Water Quality Portal, NOAA precip/tides, EPA How's My Waterway, plus Anacostia Riverkeeper and DC DOEE sonde data (fixture-backed pending real feeds)",
-          pushed: "2026-05-19",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "spicy-regs",
-          url: "https://github.com/civictechdc/spicy-regs",
-          site: "/projects/spicyregs.html",
-          score: 5,
-          tier: "active",
-          theme: "Regulations & Legislation",
-          one: "An open, contributor-friendly ETL and analysis platform for regulations.gov and adjacent federal rulemaking/lobbying data, exposed as downloadable Parquet, a Claude/MCP tool, and a hosted docs/app site.",
-          problem:
-            "Federal regulatory data (dockets, comments, rulemaking) is scattered across regulations.gov, agency-specific systems (FCC ECFS), and related transparency datasets (Federal Register, Congress.gov, FEC, lobbying, spending, courts), locked in inconsistent raw JSON with no easy, reproducible way for technical or non-technical people to explore it.",
-          why: "Not stalled — actively developed and shipping. A live flagship Civic Tech DC project, listed here only for completeness.",
-          pitch:
-            'No revival needed — this is the project other stalled regulatory-data ideas in the graveyard should be pointed toward as a model/merge target. Anyone with an old "regs.gov scraper" or "public comment analysis" idea in the archive should be redirected here rather than restarting from scratch.',
-          maturity: "deployed",
-          tech: "Python (uv, DuckDB, Parquet), Jupyter Notebook (primary language per GitHub), Vercel-hosted MCP server, mkdocs",
-          data: "regulations.gov (via Mirrulations mirror), plus FCC ECFS, Federal Register, Congress.gov, FEC, LDA, SAM.gov, USASpending, CourtListener, GAO/CRS",
-          pushed: "2026-07-23",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "ballot-sign",
-          url: "https://github.com/civictechdc/ballot-sign",
-          incubator: true,
-          score: 4,
-          tier: "superseded",
-          supersededUrl:
-            "https://code.dccouncil.gov/us/dc/council/code/sections/1-1001.16",
-          supersededName: "DC Code 1-1001.16",
-          superseded:
-            "Blocked by statute, not by a competing product: DC Code 1-1001.16 requires circulators to witness each signature in person and file completed petition sheets in hard copy, and DCBOE's own 2015 eSign pilot is dead. Digital signing needs the Council to amend the election code first, which makes this advocacy, not software.",
-          theme: "Elections, ANC & Voting",
-          one: "A proposed open-source, legally-compliant digital platform for discovering and signing DC ballot initiative petitions, replacing door-to-door canvassing.",
-          problem:
-            "DC ballot initiative campaigns rely on inefficient, costly door-to-door canvassing to collect signatures, and residents have limited awareness of active initiatives; signature collection also must be securely recorded per DC election law.",
-          why: "A project team never assembled at the January 2026 meetings; no legal, architectural, or technical work began beyond the intent statement. The repository has been archived.",
-          pitch:
-            "The concept (discover + digitally sign + securely record ballot-initiative signatures within DC election law) is still compelling civic infrastructure, but this repo never got past the intent-statement stage — a revival would start from zero: legal research on DC's e-signature/petition requirements, a look at existing open-source petition/e-signature platforms, and a real architecture/security design before any code. Modern identity-verification and e-signature tooling (and LLM-assisted legal research) make the feasibility study much cheaper to do now than in 2025.",
-          maturity: "idea-only",
-          tech: "none (no code, no primaryLanguage)",
-          data: "none",
-          pushed: "2026-01-15",
-          arch: true,
-          relevant: true,
-        },
-        {
-          name: "cib-mango-tree",
-          url: "https://github.com/civictechdc/cib-mango-tree",
-          site: "/projects/cib-mango-tree.html",
-          score: 4,
-          tier: "active",
-          theme: "Misc / Civic Data",
-          one: "An open-source Python toolkit (with a desktop GUI) for detecting coordinated inauthentic behavior (CIB) in datasets of online/social media activity.",
-          problem:
-            "Researchers, data journalists, fact-checkers, and watchdogs need an accessible way to detect coordinated inauthentic behavior (bot networks, astroturfing, copy-paste campaigns) in social media data without building custom NLP/network-analysis pipelines from scratch.",
-          why: "Not stalled — actively developed as of July 2026, with recent performance overhauls and a new GUI release.",
-          pitch:
-            'No revival needed — this is a healthy, ongoing project and a good model for what "graduated" Civic Tech DC work looks like (went from terminal UI to full GUI, has a real analyzer pipeline with n-gram/ngram-coordination detection, emoji/script-based text normalization, and parallel Polars-based processing). If listing it at all, frame it as a success story / flagship rather than a dormant idea; anyone interested in CIB detection should just contribute to it directly rather than reinvent it.',
-          maturity: "deployed",
-          tech: "Python (Polars, PyInstaller for packaging, GUI framework), MIT licensed",
-          data: "Social media datasets (user-provided, e.g. Twitter/X exports, CSVs of posts)",
-          pushed: "2026-07-20",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "congress_meeting_map",
-          url: "https://github.com/civictechdc/congress_meeting_map",
-          site: "/projects/congressional-tech.html",
-          score: 4,
-          tier: "active",
-          theme: "Misc / Civic Data",
-          one: "An interactive force-directed knowledge-graph explorer that turns congressional hackathon breakout-session discussions (transcripts/comments) into a browsable visual map of themes, ideas, threads, and comments.",
-          problem:
-            "Congressional modernization hackathon/committee breakout discussions produce rich unstructured conversation (ideas, threads, comments) that's hard to review or make sense of after the fact — no good way to explore what was actually discussed, which themes connected, or which ideas got the most engagement.",
-          why: "Not really stalled — built and shipped Sept 2025 as a single-event artifact (one hackathon's discussions); likely just completed its scope rather than being abandoned, with no indication of follow-on generalization work planned.",
-          pitch:
-            'The concept generalizes well beyond one hackathon: any meeting/summit/testimony corpus (town halls, agency listening sessions, public comment periods) could be turned into the same force-directed explorer. With modern LLMs, the manual Gemini/ChatGPT data-shaping step here could be automated into a repeatable pipeline (transcript -> clusters/ideas/threads/comments JSON-LD -> graph), turning this from a one-off single-event visualization into a reusable "meeting insight explorer" tool for civic engagement data generally.',
-          maturity: "deployed",
-          tech: "TypeScript / React + Vite + D3.js + Tailwind + Zustand + Framer Motion",
-          data: "Congressional hackathon breakout session transcripts (audio/comments), converted to JSON-LD",
-          pushed: "2025-09-20",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "dc-campaign-finance-scraper",
-          url: "https://github.com/civictechdc/dc-campaign-finance-scraper",
-          incubator: true,
-          score: 4,
-          tier: "active",
-          theme: "Elections, ANC & Voting",
-          one: "A Python CLI + library that scrapes DC's Office of Campaign Finance donation/expenditure search tool and outputs clean structured data (CSV/JSON/YAML/xlsx/html).",
-          problem:
-            "DC's official campaign finance data was only accessible through a clunky ASP.NET form-based download tool on ocf.dc.gov with no real API, making it hard to analyze who funds DC political campaigns.",
-          why: "Not stalled — actively maintained, last pushed April 2026.",
-          pitch:
-            "DC campaign finance transparency is evergreen and this repo already solved the hard part (session/cookie handling, office/candidate matching heuristics). Revive by swapping the fragile ASP scraping for whatever DC OCF's current data portal/API is (likely modernized since 2014), adding a scheduled scrape-to-database pipeline, and layering an LLM-assisted contributor/employer normalization pass (the original code had to guess office/election-year from committee name - an LLM could do this far more reliably than 2014-era heuristics) plus a simple public dashboard for donor search.",
-          maturity: "working",
-          tech: "Python (Click CLI, Requests, setup.py/PyPI package)",
-          data: "DC Office of Campaign Finance (ocf.dc.gov/serv/download.asp)",
-          pushed: "2026-04-13",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "repower-dmv-extractor",
-          url: "https://github.com/civictechdc/repower-dmv-extractor",
-          score: 4,
-          tier: "superseded",
-          supersededUrl: "https://contractors.electrifydc.org/",
-          supersededName: "Electrify DC contractor finder",
-          superseded:
-            "Electrify DC runs a live, vetted contractor finder and hosts an Electrify DMV network page, backed by DCSEU rebates and DOEE programs.",
-          theme: "Housing & Tenant Rights",
-          one: "A TypeScript CLI pipeline that extracts, cross-references, and fuzzy-matches contractor records to build a clean dataset of DMV-area businesses that do home-efficiency/electrification work.",
-          problem:
-            "DC-area residents need a trustworthy, up-to-date list of legitimate contractors who do home-efficiency and electrification work (insulation, heat pumps, etc.), matched against official licensing data so scam/unlicensed operators can be filtered out.",
-          why: "The ElectrifyDMV partnership ended for lack of sustained project leadership; the extraction pipeline never got a public destination.",
-          pitch:
-            "DC residents still have no easy, trustworthy directory of vetted home-efficiency/electrification contractors, and utility rebate/DOEE programs keep changing - this pipeline already solves the hard data-matching problem (license registry + Google Places fuzzy dedupe). Revive it by scheduling the extract/transform run periodically, adding an LLM-based reviewer for messy source records, and shipping the output as a simple searchable site (e.g. static site + Cloudflare D1) - the backend is basically done.",
-          maturity: "working",
-          tech: "TypeScript / Node (CLI via commander, axios, fuzzball, csv, winston)",
-          data: "DC contractor/business license registry + Google Places API",
-          pushed: "2025-07-28",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "ridescoredc",
-          url: "https://github.com/civictechdc/ridescoredc",
-          site: "/projects/ridescoredc.html",
-          score: 4,
-          tier: "active",
-          theme: "Transit & Mobility",
-          one: "A community pipeline and map to score DC streets for bike safety/comfort by combining open data (crashes, lane counts, speed) with transparent rulesets like Level of Traffic Stress (LTS) and BNA-style connectivity.",
-          problem:
-            "DC has no single, transparent, data-driven way to see which streets are actually safe/comfortable to bike on — existing bike-safety framing is scattered across agency data (crashes, lane counts, speed limits) with no unified public score or map.",
-          why: "Active but early — the architecture is well-specified in the README while the implementation is still thin; progress tracks available volunteer bandwidth.",
-          pitch:
-            "The concept (transparent, rules-based bike comfort scoring a la LTS/BNA, rendered as an interactive map) is exactly the kind of thing that's much easier now: DC's open data (crash, lane, ADT/speed) is more complete than in 2015-era hack projects, OSM tagging for DC streets has improved, and an LLM can quickly help encode/validate LTS-style rulesets and generate the ingest/scoring pipeline that the README already sketches but never got built — someone could plausibly turn the existing README architecture into a working v1 in a weekend using Claude Code plus a Leaflet/MapLibre frontend.",
-          maturity: "prototype",
-          tech: "Jupyter Notebook / Python (planned), Leaflet/MapLibre web map",
-          data: "DC Open Data / OSM (roads, lanes, speed, crashes) — per README, not yet actually ingested in visible code",
-          pushed: "2026-03-09",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "votecatcher",
-          url: "https://github.com/civictechdc/votecatcher",
-          site: "/projects/ballot-initiative.html",
-          score: 4,
-          tier: "active",
-          theme: "Elections, ANC & Voting",
-          one: "Open-source campaign infrastructure that automates OCR/recognition and validation of ballot petition signatures for grassroots ballot-initiative campaigns.",
-          problem:
-            "Grassroots ballot-initiative campaigns need to collect and validate large volumes of voter signatures on paper petitions to qualify for the ballot; manual signature verification/matching is slow and labor-intensive for volunteer-run campaigns.",
-          why: "Not stalled - an active, currently-maintained project (commits and CI activity as recent as the scan date). It continues the earlier Ballot-Initiative petition-verification project under a new name.",
-          pitch:
-            "This one doesn't need reviving - it's live and actively maintained today, tied to CivicTechDC's ballot-initiative project page, with LLM-based OCR (OpenAI/Mistral/Gemini) already integrated for signature recognition, a simulation mode for contributors without API keys, and multiple one-click cloud deploy paths. Anyone interested in ballot-access/organizing tech should just join the existing #vote_catcher Slack channel and contribute rather than starting fresh - the hard infrastructure (job queue, OCR pipeline, auth, multi-DB support) is already built.",
-          maturity: "working",
-          tech: "Python (FastAPI/SQLModel) backend + SvelteKit 5/TypeScript frontend",
-          data: "none",
-          pushed: "2026-07-24",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "eavs_clc",
-          url: "https://github.com/civictechdc/eavs_clc",
-          site: "/projects/data-and-democracy.html",
-          score: 3,
-          tier: "active",
-          theme: "Elections, ANC & Voting",
-          one: "Pipeline to download and clean the U.S. Election Administration and Voting Survey (EAVS) dataset for Campaign Legal Center's Voting Rights team research.",
-          problem:
-            "EAVS is a huge, messy biennial federal survey (about 400 cryptically-coded columns, about 6000 rows) on how U.S. elections are administered; making it usable for voting-rights research and longitudinal analysis requires nontrivial download, clean, and decode tooling that did not otherwise exist in an accessible form.",
-          why: "Not stalled. This is an active, ongoing Civic Tech DC project built for and with an external partner (Campaign Legal Center), still receiving feature PRs as of Feb 2026.",
-          pitch:
-            "Not really a revival candidate since it is alive and working, but the reusable pattern is strong: a clean, checksum-verified ETL pipeline for a gnarly government dataset (coded columns, biennial releases, inconsistent schemas across years) paired with a real external stakeholder (Campaign Legal Center) consuming the output. Other civic-data pipelines (EAC, FEC, Census-style surveys) could fork this template directly.",
-          maturity: "working",
-          tech: "Python (uv, pandas, calamine, ruff, just)",
-          data: "EAC Election Administration and Voting Survey (EAVS), eac.gov",
-          pushed: "2026-02-25",
-          arch: false,
-          relevant: true,
-        },
-        {
-          name: "repower-dmv",
-          url: "https://github.com/civictechdc/repower-dmv",
-          score: 3,
-          tier: "superseded",
-          supersededUrl: "https://contractors.electrifydc.org/",
-          supersededName: "Electrify DC contractor finder",
-          superseded:
-            "Electrify DC runs a live, vetted contractor finder and hosts an Electrify DMV network page, backed by DCSEU rebates and DOEE programs.",
-          theme: "Environment & Energy",
-          one: "ElectrifyDC (repo repower-dmv) — a Remix/TypeScript website helping DC residents find info and contractors for home electrification (e.g. heat pumps, induction stoves).",
-          problem:
-            "DC residents lack an easy way to learn about home electrification incentives/programs and find vetted local contractors to do heat pump/induction stove/electrical panel upgrades.",
-          why: "The ElectrifyDMV partnership ended for lack of sustained project leadership.",
-          pitch:
-            "The contractor-directory + CMS-driven content model is solid and was already validated enough to get embedded into a partner WordPress site for a grant — the underlying idea (connect residents to electrification programs/contractors) is more relevant now given IRA rebates and rising DC electrification incentives. A revival could add an LLM-based eligibility/rebate-matching assistant on top of the existing contractor data model, and modernize by dropping the custom Decap-CMS/iframe embed pattern for a simpler headless CMS or static site generator.",
-          maturity: "deployed",
-          tech: "TypeScript (Remix, Prisma/SQLite, Tailwind, Docker/Fly.io)",
-          data: "Decap-CMS managed content + contractor directory (no external gov dataset evident)",
-          pushed: "2025-10-29",
-          arch: false,
-          relevant: true,
-        },
-      ];
-
-      const GROUPS = [
-        {
-          id: "top",
-          label: "Worth reviving",
-          sub: "Dead or dormant, still relevant in 2026. Start here.",
-        },
-        {
-          id: "active",
-          label: "Still alive — go contribute",
-          sub: "Pushed within the last year. Join these rather than rebuild them.",
-        },
-        {
-          id: "superseded",
-          label: "Superseded — case closed",
-          sub: "An August 2026 scan found the need now served by an official or maintained public tool. Each file records what replaced it, so nobody rebuilds these.",
-        },
-        {
-          id: "proposed",
-          label: "Proposed — the empty drawer",
-          sub: "Ideas that don't exist yet. Pitch one and it gets a folder.",
-        },
-      ];
-      const esc = (s) =>
-        String(s).replace(
-          /[&<>"]/g,
-          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
-        );
-      const STAMP = {
-        top: "Revive",
-        active: "Active",
-        superseded: "Superseded",
-      };
-      const main = document.getElementById("main");
-
-      function card(d) {
-        const dataline =
-          d.data && !["none", "n/a", ""].includes(String(d.data).toLowerCase())
-            ? `<div class="row"><span class="k">Data source</span>${esc(d.data)}</div>`
-            : "";
-        const filelinks =
-          d.tier === "active" || d.site
-            ? `<div class="filelinks"><a href="${d.url}" target="_blank" rel="noopener">GitHub &#8599;</a>${d.site ? `<a href="${d.site}">Project page &#8599;</a>` : ""}</div>`
-            : "";
-        return `<article class="card t-${d.tier}" data-tier="${d.tier}" data-text="${esc((d.name + " " + d.one + " " + d.theme + " " + d.tech + " " + d.pitch + " " + d.problem + " " + (d.superseded || "") + " " + (d.stillGo || "")).toLowerCase())}">
-    <span class="folder-tab">${esc(d.theme)}</span>
-    <div class="card-body">
-      <div class="card-top">
-        <div>
-          <a class="repo" href="${d.url}" target="_blank" rel="noopener">${esc(d.name)}</a>
-        </div>
-        <span class="stamp">${STAMP[d.tier] || esc(d.tier)}</span>
-      </div>
-      <div class="meta-row">
-        <span>${esc(d.maturity)}</span>
-        <span>pushed ${esc(d.pushed)}</span>
-        ${d.arch ? '<span class="arch">archived</span>' : ""}
-        ${d.incubator ? '<span class="incub">incubator</span>' : ""}
-      </div>
-      <p class="one">${esc(d.one)}</p>
-      ${d.superseded ? `<p class="sup-note"><span class="k">Superseded</span>${esc(d.superseded)}${d.supersededUrl ? ` <a href="${d.supersededUrl}" target="_blank" rel="noopener">${esc(d.supersededName)} &#8599;</a>` : ""}<span class="note-when">Aug 2026</span></p>` : ""}
-      ${d.stillGo ? `<p class="go-note"><span class="k">Still open</span>${esc(d.stillGo)}${d.stillGoUrl ? ` <a href="${d.stillGoUrl}" target="_blank" rel="noopener">${esc(d.stillGoName)} &#8599;</a>` : ""}<span class="note-when">Aug 2026</span></p>` : ""}
-      ${filelinks}
-      <details>
-        <summary><span class="caret">›</span>Open the file</summary>
-        <div class="detail-block">
-          ${d.superseded ? "" : `<div class="row pitch"><span class="k">Revival pitch</span>${esc(d.pitch)}</div>`}
-          <div class="row"><span class="k">Problem it solved</span>${esc(d.problem)}</div>
-          <div class="row"><span class="k">Why it stalled</span>${esc(d.why)}</div>
-          ${dataline}
-          <div class="detail-meta"><span class="tag">${esc(d.tech)}</span></div>
-        </div>
-      </details>
     </div>
-  </article>`;
-      }
+  </div>
 
-      const PROPOSE_CARD = `<div class="propose-card" data-tier="proposed" data-text="propose new idea pitch project night slack">
-    <h3>This folder is empty</h3>
-    <p>
-      Have a civic idea worth building? Pitch it at a project night or start a
-      thread in Slack. If it finds legs, it gets filed here — with your name
-      on it.
-    </p>
-    <div class="propose-actions">
-      <a href="/events">Pitch at a project night</a>
-      <a href="/slack">Start a thread in Slack</a>
+  <div class="ad-wrap ad-cards" id="ad-cards"></div>
+  <p class="ad-empty ad-wrap" id="ad-empty">No files match that search.</p>
+
+  <section class="ad-method">
+    <div class="ad-wrap">
+      <p>
+        <strong>How this was made.</strong> On 24 July 2026, a swarm of 97 AI
+        agents (one per repo) read each repository's README and metadata and
+        scored the underlying idea for revival potential. This is a scouting
+        report on <em>ideas</em>, not a code review &mdash; treat every
+        assessment as a lead to verify, not a verdict. Stall reasons are
+        inferred from repo evidence unless stated otherwise. In August 2026 a
+        web scan checked every dormant file against current official and public
+        tools; superseded files record what replaced them. This public version
+        is curated: private repositories, empty placeholders, mirrors of
+        external tools, and internal infrastructure repos are omitted from the
+        full scan.
+      </p>
+      <p>
+        <strong>Tiers.</strong> Revive files are dormant but worth a second
+        life. Active repos were pushed within the last year &mdash; join those
+        instead of starting fresh. Superseded files record what replaced them.
+      </p>
+      <p>
+        <strong>Filing a new idea.</strong> New proposals get added by the
+        organizers. Bring yours to a
+        <a
+          href="{{ site.baseurl }}/events"
+          data-analytics-event="event_discovery_click"
+          data-analytics-location="archive_method"
+          >project night</a
+        >
+        or start a thread in
+        <a
+          href="{{ site.baseurl }}/slack"
+          data-analytics-event="slack_discovery_click"
+          data-analytics-location="archive_method"
+          >Slack</a
+        >, and if it finds legs it gets a folder here with your name on it.
+      </p>
+      <p>
+        Repository names link to GitHub &middot;
+        <a
+          href="https://github.com/civictechdc"
+          data-analytics-event="project_repository_click"
+          data-analytics-location="archive_method"
+          >github.com/civictechdc</a
+        >
+      </p>
     </div>
-  </div>`;
+  </section>
+</div>
 
-      function render() {
-        main.innerHTML = GROUPS.map((g) => {
-          const items = DATA.filter((d) => d.tier === g.id);
-          const body = items.length
-            ? `<div class="grid">${items.map(card).join("")}</div>`
-            : PROPOSE_CARD;
-          const count = items.length ? items.length : "";
-          return `<section class="group" data-group="${g.id}">
-      <div class="group-head"><h2>${g.label}</h2><span class="gcount">${count}</span></div>
-      <p class="group-sub">${g.sub}</p>
-      ${body}
-    </section>`;
-        }).join("");
-      }
-      render();
+<script>
+  (function () {
+    var DATA = [
+      {
+        name: "adopt-a-hydrant",
+        url: "https://github.com/civictechdc/adopt-a-hydrant",
+        score: 4,
+        tier: "superseded",
+        supersededUrl:
+          "https://doc.arcgis.com/en/arcgis-solutions/latest/reference/introduction-to-adopt-a-hydrant.htm",
+        supersededName: "Esri Adopt-A-Hydrant",
+        superseded:
+          "Now a maintained Esri ArcGIS Solutions product, and Fairfax, Prince William, Montgomery, and WSSC all run programs. DC's gap is adopting a program, not building software.",
+        theme: "Org Infrastructure",
+        one: 'A Rails app letting DC residents "adopt" and claim responsibility for shoveling out a specific fire hydrant after snowstorms.',
+        problem:
+          "During heavy snow, fire hydrants get buried and firefighters waste critical time digging them out; crowdsourcing hydrant-shoveling to neighbors speeds response times.",
+        why: "Last pushed Jan 2013 with no further commits; likely a seasonal hack-day project (snow-specific) that lost maintainer attention once the CfA/CfDC fellowship cycle moved on and Rails 3/Ruby 1.9.3 stack aged out.",
+        pitch:
+          'The "adopt-a-civic-object" pattern (hydrants, storm drains, benches, little free libraries) is evergreen and this repo proves it shipped and ran; a modern revival could ditch the custom Rails app entirely for a lightweight map (Mapbox/Leaflet + open muni GIS hydrant data) plus SMS/app notifications timed to NWS snow alerts, making adoption and reminders near-zero-maintenance.',
+        maturity: "deployed",
+        tech: "Ruby on Rails 3.x + Postgres",
+        data: "none",
+        pushed: "2013-01-23",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "ancElectionHistory",
+        url: "https://github.com/civictechdc/ancElectionHistory",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://code.dccouncil.gov/us/dc/council/laws/24-342",
+        stillGoName: "D.C. Law 24-342",
+        stillGo:
+          "The portal D.C. Code 1-1001.05(a)(21) mandates is codified as Not Funded, and the FY27 budget released every other conditioned piece of Law 24-342 while leaving the data portal as the last one. DCBOE ships certified CSVs back to 2012 and OpenANC covers 2020-2024, but no official longitudinal view exists, and ANC-level turnout exists nowhere.",
+        theme: "Elections, ANC & Voting",
+        one: "A data pipeline and planned Shiny/web app to visualize historical trends in DC Advisory Neighborhood Commission (ANC) election results.",
+        problem:
+          "DC has ANCs (hyperlocal elected bodies) but no easy way to see historical trends: turnout, uncontested seats, incumbency, seat vacancies/turnover over time. Data existed only as scattered board-of-elections pages and a hard-to-parse historical PDF (1979-2012).",
+        why: "Appears to be a data-collection/cleaning phase that never advanced to the planned visualization app (Shiny) or public deployment; likely a hack-day/volunteer project that lost momentum after the initial scraping work, common for Code for DC projects without a dedicated ongoing maintainer.",
+        pitch:
+          "The portal mandated by D.C. Code 1-1001.05(a)(21) sits codified as Not Funded, which turns this project into either the pilot that shames the line item into a budget or the stopgap that serves residents meanwhile. DCBOE's certified CSVs (2012-2024) and OpenANC's 2020-2024 dataset with uncontested and margin fields mean the longitudinal ANC dashboard is mostly assembly work; ANC-level turnout needs precinct-to-SMD estimation nobody has attempted.",
+        maturity: "prototype",
+        tech: "R and Python (Jupyter notebooks), R Markdown",
+        data: "DC Board of Elections website (ANC election results, scraped), anc.dc.gov (current ANC membership), historical_commissioners.pdf (1979-2012)",
+        pushed: "2020-03-04",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "ancfinder",
+        url: "https://github.com/civictechdc/ancfinder",
+        site: "/projects/ANCFinder.html",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://openanc.org/",
+        supersededName: "OpenANC",
+        superseded:
+          "OANC's official commissioner lookup and the community-run OpenANC both cover this, current through 2026.",
+        theme: "Elections, ANC & Voting",
+        one: "A public website (ancfinder.org) that lets DC residents find their Advisory Neighborhood Commission (ANC), see commissioners, boundaries on a map, meeting info, and election candidates.",
+        problem:
+          "DC's 40+ ANCs and 300+ single-member districts are hyperlocal, low-visibility government bodies; residents have no easy way to find their ANC, their commissioner, meeting schedules, or election candidates.",
+        why: "Appears to have lost active maintainers after 2019; long-running volunteer hack-day project that likely outpaced available contributor bandwidth once core features were built (classic Code for DC project lifecycle).",
+        pitch:
+          "The core need (find your ANC, your commissioner, upcoming elections, meeting minutes) is still unmet and still hyperlocal-important; a rebuild could ditch the custom Django/Docker stack for a static site + modern DC GIS open data feeds and use an LLM to summarize meeting minutes/agendas automatically, turning a maintenance-heavy 2013-era app into a nearly zero-maintenance civic info tool.",
+        maturity: "deployed",
+        tech: "Python/Django (Docker, uWSGI, nginx, Mapbox)",
+        data: "DC government ANC/ward boundary data, Mapbox",
+        pushed: "2019-04-03",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "bus-ada",
+        url: "https://github.com/civictechdc/bus-ada",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://github.com/ProjectSidewalk/SidewalkWebpage",
+        stillGoName: "Project Sidewalk",
+        stillGo:
+          "DC's per-stop ADA data still dates to the 2016 transition-plan survey, DDOT's update effort is in its 2025 cycle, and Better Bus removed 527 stops in June 2025, so the official data is stale on the stop set itself. Project Sidewalk remains actively maintained, with 205,000 labels left from its dormant DC pilot.",
+        theme: "Transit & Mobility",
+        one: "A tool to remotely audit WMATA bus stop ADA compliance by overlaying a survey form on Google Street View imagery aimed at each stop.",
+        problem:
+          "Auditing physical ADA accessibility (curb ramps, sidewalk-to-curb connections, benches/shelters) at thousands of WMATA bus stops normally requires expensive in-person site visits by DDOT/WMATA staff.",
+        why: "One-day hackathon build (#innoMAYtion, May 2015); no commits after July 2015, no README or docs, Python 2 syntax (dict.has_key/iteritems) now broken, hardcoded/expired Google Maps API usage pattern (signed_in=true) — classic hack-day project that was never picked back up after the event ended.",
+        pitch:
+          "DC's authoritative per-stop ADA dataset was captured in 2016, DDOT's ADA transition plan is in its 2025 update cycle, and Better Bus eliminated 527 stops in June 2025, so the official inventory is stale on the stop set itself, not just condition. Project Sidewalk, actively maintained with 205,000 labels from its dormant DC pilot, is the identical crowdsourcing method: the ask is restarting DC coverage with a bus-stop label type, not building from scratch.",
+        maturity: "working",
+        tech: "Python 2 (GTFS processing) + vanilla JS/jQuery/Bootstrap 3 (Google Maps/Street View frontend)",
+        data: "WMATA GTFS feed (stops.txt, stop_times.txt) + Google Street View API",
+        pushed: "2015-07-25",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "campaign-finance-explorer",
+        url: "https://github.com/civictechdc/campaign-finance-explorer",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://efiling.ocf.dc.gov/",
+        stillGoName: "OCF e-filing portal",
+        stillGo:
+          "OCF now publishes the data: e-filing search, a contributions map, and CSV and XML bulk downloads. But analysis is left to the reader — no candidate comparison, donor pattern, or cycle-over-cycle dashboards exist, official or community. The data problem this project fought is solved; the dashboard it wanted to be is still unbuilt.",
+        theme: "Elections, ANC & Voting",
+        one: "An interactive visual explorer for DC political campaign contributions, letting users filter/compare donors and money flows by candidate and ward on a map.",
+        problem:
+          "DC campaign finance data (from the Office of Campaign Finance) is hard for ordinary citizens to explore — who's funding which candidates, by ward, by contribution size — without a visual, filterable tool.",
+        why: "Last pushed May 2017; likely reliant on a custom backend API (campaign-finance.codefordc.org) that has since gone dark, and built on an aging Keshif/jQuery/Leaflet stack from the mid-2010s Code for DC hack-day era — classic volunteer-project attrition once the original maintainers moved on.",
+        pitch:
+          "The Keshif-era visual explorer died with its custom API, but the concept, a filterable visual explorer of DC contributions by candidate, ward, and donor, now sits one static build away from OCF bulk exports. Pair it with dc-campaign-finance-watch: one modern build covers both cards.",
+        maturity: "deployed",
+        tech: "JavaScript (jQuery + D3 v4 + Keshif visualization framework + Leaflet 1.0)",
+        data: "DC campaign finance contribution records (via a custom codefordc.org API, likely sourced from DC OCF filings), plus a 2012 ward geojson for map overlay",
+        pushed: "2017-05-02",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "capital-improvement",
+        url: "https://github.com/civictechdc/capital-improvement",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://dcbudget.com/",
+        stillGoName: "dcbudget.com",
+        stillGo:
+          "The CIP still ships as PDF volumes, the CFO's interactive capital dashboard (cfoinfo.dc.gov) is offline entirely, and the quarterly Capital Financial Status Report tracks spend against lifetime authority but never how planned costs drift between CIP editions. That cross-edition join is the build.",
+        theme: "Budget & Spending",
+        one: "A searchable web explorer that scrapes DC's annual six-year Capital Improvement Plan (buildings/roads investment) out of locked PDF/XML files and lets residents track how project costs and timelines change year over year.",
+        problem:
+          "DC's capital improvement plans (multi-year budget for infrastructure like schools, roads, buildings) were published only in non-open, hard-to-parse formats, making it nearly impossible for residents to see how planned projects and their costs/timelines evolved over time.",
+        why: "Appears to be a Code for DC hack-project that got a working v1 shipped and iterated for about a month (June-July 2016), then lost momentum once the initial volunteer(s) moved on; no updates since, and the underlying data source/parsing likely needs re-scraping each year, which nobody kept doing.",
+        pitch:
+          "The gap narrowed but sharpened: the CFO's quarterly Capital Financial Status Report tracks project spend against lifetime budget authority, but nothing anywhere tracks how planned costs and schedules drift from one CIP edition to the next, and the CFO's old interactive dashboard is dead. dcbudget.com, a solo volunteer project, exports project-level JSON and Excel with each deployment; partner with it rather than rebuilding, and add the cross-edition join the official tools avoid.",
+        maturity: "deployed",
+        tech: "JavaScript (Gulp/Bower frontend) + Ruby ETL scraper",
+        data: "DC OCFO Capital Improvement Plan documents (PDF/XML), scraped via custom Ruby ETL",
+        pushed: "2016-07-20",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "CashBailApp",
+        url: "https://github.com/civictechdc/CashBailApp",
+        score: 4,
+        tier: "superseded",
+        supersededUrl:
+          "https://www.communityjusticeexchange.org/en/nbfn-directory",
+        supersededName: "National Bail Fund Network",
+        superseded:
+          "DC abolished cash bail in 1992, so there is no local use, and national bail funds run their own infrastructure. Congress could change this: H.R. 5214 passed the House in late 2025.",
+        theme: "Criminal Justice",
+        one: "A web app (Java/Spring Boot) built at a 2020 NYC Coders BLM Hackathon to connect people held on cash bail with community donors/advocates and local nonprofit bail funds.",
+        problem:
+          "Cash bail disproportionately jails poor and Black defendants who are legally presumed innocent simply because they can't pay; community bail funds exist but lack a platform to connect vetted cases with willing donors/advocates.",
+        why: "Likely a one-off hackathon project (built at NYC Coders BLM Hackathon, not originally a Civic Tech DC project) with no full-time maintainer after the event; last commit 2022, never deployed publicly, and it needed real nonprofit partners to operate that likely never materialized.",
+        pitch:
+          'Cash bail reform and community bail funds (e.g., The Bail Project, National Bail Fund Network) are still very active causes; a modern rebuild as a lightweight matching/crowdfunding platform (Next.js + Stripe/GiveButter integration, or just an LLM-assisted intake form for nonprofits to vet and publish cases) could plug directly into existing bail fund orgs\' workflows instead of trying to be its own system of record — the core "case marketplace connecting funders to vetted need" concept is sound and the hard part (nonprofit partnerships, vetting) was already the intended model here.',
+        maturity: "prototype",
+        tech: "Java 8 / Spring Boot / Thymeleaf / Bootstrap4 / Maven",
+        data: "none (self-contained app; would need to integrate with local nonprofit bail funds' data/workflows)",
+        pushed: "2022-06-21",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "cfsa-referral",
+        url: "https://github.com/civictechdc/cfsa-referral",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://211warmline.dc.gov/",
+        supersededName: "DC 211 Warmline",
+        superseded:
+          "The 211 Warmline (February 2025, CFSA's Office of Thriving Families with DBH) is a resident-facing referral hub, not a caseworker decision tree. But an internal CFSA routing tool cannot be built or adopted by outside volunteers, and the District now funds the hub that owns the service inventory it would need. Revisit only if CFSA initiates the ask.",
+        theme: "Social Services & Benefits",
+        one: "A React decision-tree app for CFSA caseworkers to answer yes/no questions in the field and get routed to the right voluntary child-welfare program.",
+        problem:
+          "DC CFSA caseworkers in the field had no simple tool to determine which of 6 voluntary programs (crisis stabilization, parent education, housing, substance-abuse referral, etc.) a client/family was eligible for — decisions relied on caseworker memory of scattered eligibility criteria.",
+        why: "Hackathon-born prototype that likely needed live FACES system integration and ongoing CFSA agency partnership/data-sharing to become production-usable; volunteer momentum ended ~Feb 2018 (last push) with wishlist items like FACES write-back and program enrollment never built.",
+        pitch:
+          "The core idea — a guided eligibility decision tree for a confusing multi-program benefits/referral system — is a durable, high-value civic-tech pattern (applies to CFSA today, plus any DC agency with overlapping voluntary programs). Reviving it now is much easier: an LLM could ingest the actual program eligibility rules/regs and generate/maintain the decision tree instead of hand-coding it, and a simple hosted form replaces the custom React app entirely. Real starting assets: the original decision-tree logic, 6 program definitions, and named CFSA stakeholders who could validate a rebuild if still reachable.",
+        maturity: "prototype",
+        tech: "React (Create React App) + Jest, deployed via Netlify, Docker/Travis CI setup",
+        data: "CFSA (DC Child and Family Services Agency) program eligibility criteria; FACES case management system (referenced, not integrated)",
+        pushed: "2018-02-22",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "chat-with-your-anc",
+        url: "https://github.com/civictechdc/chat-with-your-anc",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://oanc.dc.gov/",
+        stillGoName: "OANC minutes",
+        stillGo:
+          "The Office of ANCs posts minutes centrally for all 46 ANCs, FY24 through FY26, collected but uneven, with about a sixth as image-only scans. No cross-ANC full-text search exists; OANC's own site search cannot see inside the documents.",
+        theme: "Misc / Civic Data",
+        one: 'A proposed chatbot to let DC residents "chat with" their Advisory Neighborhood Commission (ANC) meeting minutes/records via LLM.',
+        problem:
+          "ANCs are DC's hyperlocal government bodies, but their meeting minutes are scattered, inconsistent PDFs/text dumps that residents never read, making it hard to track what's happening in local government (zoning, liquor licenses, development) at the neighborhood level.",
+        why: "Likely a hack-day idea where only the tedious data-collection step (manually gathering ANC1A minutes) got done before interest/time ran out; no LLM chat layer was ever built.",
+        pitch:
+          "The Office of ANCs solved collection: minutes for all 46 ANCs are centrally posted for FY24 through FY26, uniform in location if not in format, with about a sixth needing OCR. The build is exactly this idea's second half: full-text and retrieval-augmented search across the corpus, with citations back to the source minutes.",
+        maturity: "idea-only",
+        tech: "none (plain text data only, no code)",
+        data: "ANC1A meeting minutes (manually collected text files, 2021-2023)",
+        pushed: "2023-11-08",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "clean-slate",
+        url: "https://github.com/civictechdc/clean-slate",
+        site: "/projects/clean-slate.html",
+        score: 4,
+        tier: "top",
+        stillGo:
+          "Automatic relief is still phasing in, with courts given until October 2027 and a ten-year automatic tier, so motion-based relief (misdemeanor five years, felony eight from completion of sentence, plus actual innocence) is the near-term path, and no eligibility screener exists for it, official or otherwise.",
+        theme: "Criminal Justice",
+        one: "A guided-interview website that walks DC residents/attorneys through whether their criminal record is eligible to be sealed/expunged, with forms and attorney lookup tools.",
+        problem:
+          "DC legal clinics needed a fast way to determine if a client's criminal record qualifies for sealing/expungement, generate intake referrals, train new attorneys on the process, and give clients self-service guidance plus the actual court forms.",
+        why: "Last push Jan 2017; the README notes a hand-off to MissionLaunch's fork, and the eligibility logic was never maintained here after that.",
+        pitch:
+          "DC's Second Chance Amendment Act retires the original wizard, but automatic relief phases in slowly: courts have until October 2027, and the automatic tier requires ten years. The near-term need is an eligibility screener for motion-based relief, the misdemeanor five-year, felony eight-year (from completion of sentence), and actual-innocence paths. No official checker exists, and legal-aid intake is a form, not a screener.",
+        maturity: "deployed",
+        tech: "Static HTML/JS site with a JSON-driven rules/flow engine (no backend), bilingual (en/es)",
+        data: "DC criminal record sealing/expungement eligibility rules (statutory logic, e.g. § 48-904.01); combined-flow.json wizard tree",
+        pushed: "2017-01-27",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "dc-campaign-finance-watch",
+        url: "https://github.com/civictechdc/dc-campaign-finance-watch",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://efiling.ocf.dc.gov/",
+        stillGoName: "OCF e-filing portal",
+        stillGo:
+          "OCF now publishes the data: e-filing search, a contributions map, and CSV and XML bulk downloads. But analysis is left to the reader — no candidate comparison, donor pattern, or cycle-over-cycle dashboards exist, official or community. The data problem this project fought is solved; the dashboard it wanted to be is still unbuilt.",
+        theme: "Elections, ANC & Voting",
+        one: "A full-stack open API and web dashboard for exploring DC campaign contribution data, letting citizens compare candidates' fundraising side by side.",
+        problem:
+          "DC campaign finance data from the Office of Campaign Finance was historically opaque and hard to query or compare across candidates; this project aimed to expose it via an open API plus visualizations.",
+        why: "Long-running Code for DC hack-night project that got real sustained contributor effort over years but eventually lost active maintainers; likely stalled on OCF data-format changes/scraper rot and the burden of maintaining a Mongo+Docker stack with no dedicated owner.",
+        pitch:
+          "The original ran for years at campaign-finance.codefordc.org on scraped data and a Mongo stack. A rebuild is far cheaper now: OCF bulk CSV and XML feed a static pipeline directly, no scraper and no database. The unbuilt layer is the analytics — candidate comparisons, donor patterns, small-dollar versus PAC shares, cycle-over-cycle trends — with the 2026 races as the launch moment.",
+        maturity: "deployed",
+        tech: "Node.js/Express + MongoDB + React/Webpack, Dockerized",
+        data: "DC Office of Campaign Finance (ocf.dc.gov)",
+        pushed: "2022-12-06",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "dcps-budget",
+        url: "https://github.com/civictechdc/dcps-budget",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://dcpsbudget.com/",
+        supersededName: "dcpsbudget.com",
+        superseded:
+          "DCPS runs an official per-school budget site with worksheets, comparisons, and an archive back to SY22-23, four years of comparable data, enough for recent trend analysis.",
+        theme: "Budget & Spending",
+        one: "A public-facing interactive visualization of the DC Public Schools (DCPS) budget, built as a static-site data viz app with a Gulp/Bower/npm toolchain.",
+        problem:
+          'DC school budgets are notoriously opaque (per-pupil funding formulas, line items scattered across PDFs/Excel), making it hard for parents, teachers, and advocates (partnered with "Our DC Schools") to understand or scrutinize how DCPS money is allocated.',
+        why: "Appears to be a single-budget-cycle (FY16) project tied to that year's advocacy push; once the FY16 cycle closed there was no maintainer or funding to keep re-pointing it at new budget years, and it was never generalized into a reusable/data-refreshable tool.",
+        pitch:
+          "Budget transparency for DC schools is still a live pain point every budget season, and the interactive-visualization concept holds up well. A revival wouldn't need the old Gulp/Bower toolchain at all: pull DCPS budget data directly (many jurisdictions now publish machine-readable open-data budget feeds), rebuild the front end in a modern lightweight stack (e.g., static site + D3/Observable Plot), and use an LLM to auto-generate plain-language summaries of line-item changes year over year — turning a one-off FY16 snapshot into an always-current, self-updating budget explainer.",
+        maturity: "deployed",
+        tech: "HTML/JS (Gulp build, Bower dependencies)",
+        data: "DC Public Schools budget data (FY16 budget office)",
+        pushed: "2015-04-22",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "districthousing",
+        url: "https://github.com/civictechdc/districthousing",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://dhcd.dc.gov/page/housing-locator-services",
+        supersededName: "DC housing locator services",
+        superseded:
+          "Housing applications moved into official portals (DCHA's agency portal, the IZ lottery, DCHousingSearch). The real blocker for cross-program intake is consent and data-sharing, not PDF filling.",
+        theme: "Housing & Tenant Rights",
+        one: "A Rails app that lets caseworkers fill out one online intake form and auto-generates the multiple separate PDF applications needed for DC Section 8 housing programs.",
+        problem:
+          "DC housing caseworkers had to manually re-enter the same client data across multiple redundant paper/PDF Section 8 applications, wasting time and increasing error risk for a population that badly needs efficient help.",
+        why: "No commits since January 2018. The app depends on tooling that has since aged out (old Ruby, pdftk, Cloud9) and on agency-specific PDF forms that need updating as DC's housing forms change; nothing was kept current after the 2013-2018 Code for DC era.",
+        pitch:
+          "The \"one form, many auto-filled PDFs\" pattern is still exactly the right shape for benefits/housing intake, and it's much easier now: replace pdftk/pdf-forms gem plumbing with modern PDF-fill libraries or an LLM-assisted form-mapping layer, skip the Rails/Docker/Cloud9-era setup entirely with a lightweight serverless form + PDF-fill pipeline, and pair it with current DC Housing Authority forms; the caseworker pain point (redundant data entry across agency PDFs) hasn't gone away.",
+        maturity: "deployed",
+        tech: "Ruby on Rails (Docker, pdftk/pdf-forms gem)",
+        data: "none (uses local PDF form templates for DC housing agency applications)",
+        pushed: "2018-01-09",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "eligibility-blueprint",
+        url: "https://github.com/civictechdc/eligibility-blueprint",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://github.com/MyFriendBen/benefits-api",
+        supersededName: "MyFriendBen",
+        superseded:
+          "MyFriendBen on PolicyEngine is exactly this product: an open-source, white-label, multi-state benefits screener, funded and actively maintained.",
+        theme: "Social Services & Benefits",
+        one: "A generic React app that turns a spreadsheet of questions/answers/programs into a decision-tree eligibility screener webform",
+        problem:
+          "DC residents (starting with CFSA child/family services clients, later ERAP rental assistance applicants) needed a simple way to answer a few questions and find out which government assistance programs they qualify for, without a caseworker manually walking them through eligibility rules",
+        why: "Last pushed March 2018; appears to have been a hackathon/prototype-to-pilot project (grew out of codefordc/cfsa-referral) that got two real deployments but no ongoing maintainer or generalized productization after that — never expanded beyond CSV-driven config or got a real hosting/ops story.",
+        pitch:
+          "The core idea (spreadsheet-configurable decision-tree eligibility screener for benefits programs) is exactly the kind of thing govtech needs and is still built ad hoc today; reviving it with a modern no-code form builder, LLM-assisted rule extraction from program regulations, and a real hosting/admin UI instead of raw CSVs would make it dramatically easier to spin up new benefits screeners (SNAP, TANF, housing, ERAP-style emergency programs) for any jurisdiction.",
+        maturity: "working",
+        tech: "JavaScript / React (Create React App)",
+        data: "CFSA/ERAP eligibility CSVs (Google Sheets), configured via .env",
+        pushed: "2018-03-14",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "open211",
+        url: "https://github.com/civictechdc/open211",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://211warmline.dc.gov/",
+        supersededName: "DC 211 Warmline",
+        superseded:
+          "The directory need is served twice over, by the official DC 211 Warmline and findhelp. The remaining gap, no open API for the city's directory data, is procurement advocacy rather than code.",
+        theme: "Regulations & Legislation",
+        one: "An open, standardized API and website for DC's 211 human/social services directory, built on the Ohana API design so DC's out-of-date 211 data could be interoperable and commonly maintained.",
+        problem:
+          "DC lacked a single up-to-date, interoperable directory of health/human/social services, making it hard for people in need to find eligible resources, and prior resource-directory efforts kept dying because maintaining the data was too costly.",
+        why: "Classic hack-day fragmentation: the interesting logic (API, website, import script) was split across several external repos and Heroku apps rather than consolidated here, and once the initiating volunteers moved on (one went on to found the Open Referral standard itself) there was no maintainer left to keep DC's data pipeline running.",
+        pitch:
+          "The Open Referral / HSDS data standard this project pioneered on is now mature and widely adopted (2-1-1 orgs, HHS, many cities use it), and LLMs make the hardest original problem - normalizing messy, stale service-provider data and keeping it current - dramatically cheaper via scraping/entity resolution/nightly refresh agents; a revival could pull DC's current 211/Aunt Bertha-style data, publish it as an Open Referral-compliant API, and layer an LLM chat interface on top for eligibility matching.",
+        maturity: "prototype",
+        tech: "Ruby (data import script) + static HTML/CSS front end; API built on Ohana API (Node/Rails-family human-services API spec)",
+        data: "DC 211 community resource data (Ohana API spec / Open Referral)",
+        pushed: "2016-02-01",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "rent-stabilization",
+        url: "https://github.com/civictechdc/rent-stabilization",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://rentregistry.dc.gov/",
+        stillGoName: "DC RentRegistry",
+        stillGo:
+          "The November 2025 re-registration deadline filled the registry, now 19,582 registrations covering roughly 194,000 units in free bulk CSVs refreshed daily. Coverage chasing is over; what is missing is the analytics layer, compliance and rent-adjustment views, plus public surfacing of the monthly reports section 42-3502.03c already requires of DHCD.",
+        theme: "Housing & Tenant Rights",
+        one: "A data pipeline to infer which DC rental units are subject to rent stabilization (rent control) and model the effect of policy changes, since no direct public dataset says which units are covered.",
+        problem:
+          "DC's rent control law exempts many units (post-1976 buildings, small landlords with ≤4 units, voluntary agreements, etc.) but there is no public list of which specific units/buildings are actually rent-controlled, making the law's real coverage and the impact of proposed changes (e.g., moving the exemption cutoff from 1976 to 1986) impossible to assess without inference from property records.",
+        why: "Analysis reached a first-pass conclusion (e.g., ~48% of DC housing units are in buildings with 4-or-fewer units), but the visualization was explicitly marked work-in-progress using simulated (not real) data, and commits stopped in March 2017 after final analysis tweaks. No technical blocker is evident; the repo doesn't record why work ended.",
+        pitch:
+          "DHCD's rent registry launched in June 2025 with free bulk CSV exports refreshed daily, and the November re-registration deadline filled it: 19,582 registrations covering roughly 194,000 units. The build is no longer chasing registrations. It is the analytics layer the registry still lacks: compliance views, rent-adjustment tracking, and surfacing the monthly section 42-3502.03c reports DHCD owes the Council.",
+        maturity: "working",
+        tech: "R and Python (data wrangling/analysis scripts), Shiny (visualization demo)",
+        data: "DC Open Data (CAMA residential/condo/commercial property assessment datasets), ACS, HUD PHA inventory, CPI-W",
+        pushed: "2017-03-16",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "rfj_expungement",
+        url: "https://github.com/civictechdc/rfj_expungement",
+        score: 4,
+        tier: "top",
+        stillGoUrl: "https://www.risingforjustice.org/",
+        stillGoName: "Rising for Justice",
+        stillGo:
+          "Rising for Justice still determines eligibility manually by phone and email intake, and no rules-as-code exists for the amended DC statute. Worth checking Code for America's DC policy-design work for reusable artifacts before building.",
+        theme: "Criminal Justice",
+        one: "A Next.js web form that encodes Rising for Justice's legal logic to help pro bono attorneys determine whether a DC client's criminal record is eligible for expungement.",
+        problem:
+          "Pro bono lawyers at legal clinics need to quickly and correctly evaluate whether a client's DC criminal record qualifies for expungement/sealing — the underlying law is a complex, jurisdiction-specific decision tree that's easy to get wrong manually.",
+        why: "Unclear — development stopped abruptly in January 2023 after a long active run (97 merged PRs), which reads more like an engagement winding down than an idea failing. The repo doesn't record why.",
+        pitch:
+          "Rising for Justice still determines expungement eligibility manually by phone and email intake. The 2025 statute rewrite invalidated this repo's decision logic but shrank the build to something tractable: rules-as-code for D.C. Code sections 16-801 through 16-806 as amended. Rasa Legal proves the model commercially in three other states, and Code for America's DC policy-design work is worth mining for artifacts before building.",
+        maturity: "working",
+        tech: "JavaScript/TypeScript, Next.js, Jest, CircleCI",
+        data: "none (encodes RFJ's internal legal eligibility rules, no external dataset)",
+        pushed: "2023-01-04",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "rfk-community",
+        url: "https://github.com/civictechdc/rfk-community",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://ourrfk.dc.gov/",
+        supersededName: "OurRFK",
+        superseded:
+          "Overtaken by events: the stadium deal was approved and the District ran its own master-plan engagement; the site's future is decided.",
+        theme: "Misc / Civic Data",
+        one: "A civic engagement tool built with DC Councilmember Charles Allen's office to collect resident input on redeveloping the 170-acre former RFK stadium site in Ward 7.",
+        problem:
+          "DC residents had no accessible, structured way to weigh in on redevelopment plans for a major public land parcel (former RFK stadium, NPS-owned, leased to DC through 2038) as legislation moved to transfer the land to DC government control.",
+        why: "Unclear — commits grew sporadic after the initial 2019 survey push and stopped in April 2023. The repo doesn't record a formal wrap-up.",
+        pitch:
+          "The pattern — partner directly with a council office to run a structured public-input survey on a live land-use decision, with results visualized back to the community — is a reusable civic-tech template, not just a one-off. Today this could be rebuilt fast with a lightweight form (Typeform/Google Forms as they already used), LLM-based thematic coding of open-ended comments instead of manual review, and a public results dashboard, dramatically cutting the Django/React build cost the original team paid for.",
+        maturity: "working",
+        tech: "Django + React.js",
+        data: "Google Forms survey embedded in site; DC Council/NPS land data (implied)",
+        pushed: "2023-04-21",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "ballot-initiative-dashboard",
+        url: "https://github.com/civictechdc/ballot-initiative-dashboard",
+        score: 3,
+        tier: "top",
+        stillGoUrl: "https://www.dcboe.org/",
+        stillGoName: "DCBOE",
+        stillGo:
+          "DCBOE still publishes measures as titles plus loose PDFs, with its own eight-step pipeline documented but never rendered as per-measure status with signature clocks. Only the foie gras measure is certified for November 2026; the wage and rent-freeze initiatives missed the July deadline and target 2027, the cycle this build should aim at.",
+        theme: "Elections, ANC & Voting",
+        one: "A proposed dashboard to track future/upcoming DC ballot initiatives",
+        problem:
+          "DC residents and civic groups have no easy way to track ballot initiatives that are being proposed or gathering signatures before they reach the ballot, making it hard to engage early or plan advocacy.",
+        why: "Never got past the initial scaffolding/data-gathering stage; abandoned after one month with no code written, likely a hack-day idea that lost momentum",
+        pitch:
+          "DCBOE's current-measures page lists every measure as a title plus loose PDFs, with no status pipeline, signature clocks, or machine-readable export, and Ballotpedia only loosely tracks certification. The wage and rent-freeze initiatives that missed the July 2026 deadline are aiming at 2027; a structured tracker of DCBOE's own eight-step pipeline, shipped before that cycle heats up, is a small, high-visibility build.",
+        maturity: "idea-only",
+        tech: "None (no code committed; primaryLanguage null)",
+        data: "Likely DC Board of Elections ballot initiative filings (unconfirmed, no code exists to verify)",
+        pushed: "2023-03-15",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "baltimore-lunch",
+        url: "https://github.com/civictechdc/baltimore-lunch",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://cityservices.baltimorecity.gov/summerfood/",
+        supersededName: "Baltimore summer food",
+        superseded:
+          "Official tools run live every season at three levels: USDA's site finder, Maryland MSDE's search, and Baltimore City's own map, with SUN Bucks reducing the need further.",
+        theme: "Social Services & Benefits",
+        one: "A geolocation map app pinpointing free summer lunch locations for Baltimore students.",
+        problem:
+          "Low-income students who rely on free/reduced school lunch lose that food access over summer break; USDA/city summer meal programs exist but families often don't know where sites are.",
+        why: "Classic single-weekend hackathon project (Code for DC/Baltimore 2015) — built, deployed, and shipped for one event, then abandoned once the hack day ended; no maintainer continued it.",
+        pitch:
+          "The core idea (find-a-free-meal-site map) is still needed every summer in every city and is now much easier: USDA publishes a public Summer Meals site-locator API/dataset, so a modern version could pull live official data instead of crowdsourced GitHub issues, and be built as a lightweight static map (Mapbox/Leaflet + GeoJSON) deployable in a day with an LLM doing the data cleanup/geocoding.",
+        maturity: "deployed",
+        tech: "CSS/JS front-end (Bower + Gulp build)",
+        data: "Baltimore summer free-lunch site locations (crowdsourced via GitHub issues)",
+        pushed: "2015-04-29",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "bikeshare-odds",
+        url: "https://github.com/civictechdc/bikeshare-odds",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://capitalbikeshare.com/bike-angels",
+        supersededName: "Bike Angels",
+        superseded:
+          "Superseded sideways: no maintained tool forecasts CaBi availability, and fifteen years of abandoned prototypes is the demand signal. Real-time status is commoditized across the major apps, and Lyft's Bike Angels rebalances scarcity with rider incentives instead of predictions. Skip unless a specific underserved corridor shows up.",
+        theme: "Transit & Mobility",
+        one: "A Leaflet.js map of DC Capital Bikeshare stations showing the odds of finding an available bike based on historical dock data.",
+        problem:
+          "Bikeshare riders can't tell, at a glance, how likely a given station is to have an available bike (or open dock) at a given time — leading to wasted trips to empty/full stations.",
+        why: "Likely a single-hack-day project that reached a working demo but wasn't maintained past March 2014 — no further commits, no community adoption.",
+        pitch:
+          "The core visualization idea (probability-of-availability heatmap by station and time) is still genuinely useful for bikeshare/scooter riders and is now much easier to build: Capital Bikeshare publishes live GBFS feeds and historical trip data directly, so a modern version could use real-time + ML-based short-term forecasting instead of static historical averages, and ship as a lightweight PWA with push notifications for favorite stations.",
+        maturity: "deployed",
+        tech: "JavaScript/Leaflet.js (client-side, static HTML/CSS/JS)",
+        data: "Capital Bikeshare dock history (opendatadc.org, via DSSG)",
+        pushed: "2014-03-19",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "capital-nature-ingest",
+        url: "https://github.com/civictechdc/capital-nature-ingest",
+        score: 3,
+        tier: "superseded",
+        superseded:
+          "Capital Nature curates its own events calendar now, with dozens of listings maintained through the current season.",
+        theme: "Misc / Civic Data",
+        one: "A scraper pipeline that pulls nature/outdoor events from dozens of DC-area sources (NPS, Eventbrite, park/nature orgs) and feeds them into the Capital Nature events calendar.",
+        problem:
+          "DC has many scattered nature and outdoor event sources (parks, NPS, nonprofits, Eventbrite listings) with no unified calendar; Capital Nature (a 501c3) needed an automated way to aggregate them into one events calendar for area residents.",
+        why: "No commits since Oct 2021. The per-source scraper model (each event source needs its own scraper, per the README's contributing section) is a heavy ongoing maintenance burden for a volunteer project.",
+        pitch:
+          'The concept (aggregate fragmented local event sources into one calendar) is evergreen and now much cheaper to execute: LLM-based extraction can replace bespoke per-source scrapers (the original repo\'s issue tracker was literally "one scraper per event source needs writing/maintaining" - a maintenance nightmare an LLM scraper/parser can generalize away), and a small serverless function + cheap hosting removes the CDK/Lambda complexity. Worth reviving as a general-purpose "local events aggregator" template usable beyond nature/DC.',
+        maturity: "deployed",
+        tech: "Python 3.6 (scrapers), AWS Lambda/CDK, Docker",
+        data: "Web scraping of NPS API, Eventbrite API, and DC-area nature/outdoor org event pages",
+        pushed: "2021-10-14",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "communityresources",
+        url: "https://github.com/civictechdc/communityresources",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://211warmline.dc.gov/",
+        supersededName: "DC 211 Warmline",
+        superseded:
+          "The directory need is served twice over, by the official DC 211 Warmline and findhelp. The remaining gap, no open API for the city's directory data, is procurement advocacy rather than code.",
+        theme: "Social Services & Benefits",
+        one: 'A static web front-end (index.html + JS/CSS) for browsing DC community/social-service resource data, hosted at communityresourcedata.codefordc.org, formerly branded "DC Open 211".',
+        problem:
+          "Surface DC's scattered social/community service resources (the kind of info 211 hotlines provide - food, housing, health, benefits referrals) in a searchable/browsable web format, likely for residents or caseworkers to find help services more easily than through DC's official 211 system.",
+        why: "Looks like a single-person/small hack-day build that hit a data-maintenance wall (a directory of resources needs ongoing curation) and a technical stumble (last commit's confession of possibly breaking the page); no further commits after April 2014, likely abandoned as interest/volunteer time moved on.",
+        pitch:
+          "The core idea - a clean, always-current directory of DC social services (food banks, shelters, benefits offices, health clinics) - is still needed; DC 211 and similar directories are notoriously stale. A revival could pull from modern open data (DC.gov open data portal, 211Search/AWS 211 API, 2-1-1 Metro DC feeds) and use an LLM to normalize/dedupe listings and auto-flag stale entries, something infeasible to hand-maintain in 2014 but cheap now.",
+        maturity: "deployed",
+        tech: "Static HTML/CSS/JS (no backend evident)",
+        data: "DC 211 / community resource data (unclear original source), 2013-2014",
+        pushed: "2014-04-09",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "curiouscity",
+        url: "https://github.com/civictechdc/curiouscity",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://51st.news/",
+        supersededName: "The 51st",
+        superseded:
+          "The 51st, the worker-run successor to DCist, runs reader-question journalism for DC.",
+        theme: "Misc / Civic Data",
+        one: "A Rails web app letting residents submit and vote on questions about their city, with selected questions investigated and answered by journalists/reporters.",
+        problem:
+          "Community members have questions about how their city works but no structured channel to surface which questions matter most to residents or get them answered by journalists/investigators.",
+        why: "Unclear — appears to be a Code for DC fork/adaptation of an existing Chicago-based (WBEZ Curious City) concept; likely a single hack event that wasn't continued once the initial build was done (only 5 commits, all from early 2015).",
+        pitch:
+          "The crowdsourced-investigative-journalism-question model (à la WBEZ's original Curious City) is still compelling for local newsrooms or civic orgs wanting community-driven accountability journalism; a modern rebuild could ditch the custom Rails admin/voting stack for a lightweight Next.js + Postgres app, use LLMs to auto-cluster/dedupe submitted questions and draft initial research briefs for reporters, and skip Disqus entirely in favor of native threaded comments.",
+        maturity: "working",
+        tech: "Ruby on Rails 4.0",
+        data: "none",
+        pushed: "2015-01-04",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "DC-Budget-Sankey",
+        url: "https://github.com/civictechdc/DC-Budget-Sankey",
+        score: 3,
+        tier: "top",
+        stillGoUrl: "https://www.dccouncilbudget.com/analytics",
+        stillGoName: "Council budget lookup",
+        stillGo:
+          "This repo's own demo once ran and died along with its data source (cfoinfo.dc.gov), so no flow visualization of the DC budget exists today, while structured data to feed one finally does.",
+        theme: "Budget & Spending",
+        one: "A Sankey diagram visualizing how DC's budget funds flow into specific government agencies.",
+        problem:
+          "DC's budget is published as opaque tabular financial data; ordinary residents can't see at a glance where tax dollars actually go by agency/fund.",
+        why: "Single hack-day/hackathon-style project (created Oct 2015, last commit Feb 2016 plus an automated civic.json spec-update PR merged later); no ongoing maintainer, no license file (flagged by the bot PR), budget data was hardcoded/manually converted so it would go stale every fiscal year without upkeep.",
+        pitch:
+          "This repo's demo once ran and died with its cfoinfo.dc.gov data source. No flow visualization of the DC budget exists today, and the niche is unclaimed: rebuild the Sankey on dcbudget.com's structured exports and the Council lookup tool's data instead of hand-converted PDFs.",
+        maturity: "working",
+        tech: "JavaScript (D3.js-style Sankey), static site on GitHub Pages",
+        data: "DC CFO budget/finance data (cfoinfo.dc.gov)",
+        pushed: "2016-02-01",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "dc-council-chat",
+        url: "https://github.com/civictechdc/dc-council-chat",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://dccouncil.gov/hearings/",
+        supersededName: "Council hearings",
+        superseded:
+          "Council streams are plentiful and official, and YouTube's native live chat on the Committee of the Whole stream covers the co-watching layer.",
+        theme: "Misc / Civic Data",
+        one: "A site to watch DC Council meetings live and chat about them alongside other civically-engaged viewers.",
+        problem:
+          "DC Council meetings are long, low-production-value government livestreams that few residents watch or understand; there was no companion layer for real-time public commentary/context while a meeting is happening.",
+        why: 'Classic hack-day churn: pivoted backend mid-project (scraper -> Horizon rewrite that discarded prior work per "removing all previous" commit), then went dark after ~2 months with no chat UI or scraper actually shipped in the final state — likely lost momentum after the hackathon ended and RethinkDB Horizon itself was discontinued by its maker shortly after (2016), stranding the chosen stack.',
+        pitch:
+          "The idea (co-viewing + chat layered on government livestreams, like Twitch chat for local legislature) is still fresh and now much easier: DC Council streams are on YouTube/Granicus with timestamps, and an LLM could auto-summarize agenda items, tag speakers, and surface relevant bill/vote context in the chat in real time, turning idle chatter into an annotated public record. Modern tooling (Supabase/Firebase realtime or Durable Objects for the chat backend, a serverless scraper for the meeting calendar, and an LLM co-pilot for live context) would let one person rebuild this in a weekend instead of standing up self-hosted RethinkDB Horizon.",
+        maturity: "prototype",
+        tech: "JavaScript (RethinkDB Horizon backend, Docker Compose dev environment)",
+        data: "DC Council meeting calendar (via scraper)",
+        pushed: "2016-08-07",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "dc_bus_stuff",
+        url: "https://github.com/civictechdc/dc_bus_stuff",
+        score: 3,
+        tier: "top",
+        stillGo:
+          "DDOT's bus-lane layer is twelve unlisted segments with no install dates, WMATA reports bus performance at system and line level only, and the public join is a single roll-up figure (13 percent faster since 2019). Boston's TransitMatters proves stop-pair transit analysis in production; nobody has built the DC lane-by-lane version.",
+        theme: "Transit & Mobility",
+        one: "A 2019 Code for DC repo exploring DC bus GPS/bustime data to evaluate bus infrastructure, starting with the H Street bus lane pilot.",
+        problem:
+          "DC transit riders and planners lack accessible tools to evaluate whether bus infrastructure interventions (like dedicated bus lanes) actually improve reliability, or to identify where buses are slow/unreliable and where new interventions are needed.",
+        why: "Looks like a single hack-night/hack-day exploration that got one round of real analysis (H Street pilot) done, then the more ambitious ideas (camera counting, bus-stop quality score) were never picked up; no commits after Sept 2019, likely lost momentum after the initial volunteer(s) moved on.",
+        pitch:
+          "Still nobody's build: DDOT publishes a thin bus-lane layer, WMATA publishes system- and line-level performance, and the only public join is WMATA's single roll-up that priority segments run 13 percent faster since 2019. Boston's TransitMatters dashboard proves stop-pair transit analysis in production. A lane-by-lane bus priority scorecard, with install dates reconstructed from DDOT project pages, remains the most novel local build in this archive.",
+        maturity: "prototype",
+        tech: "Jupyter Notebook / Python",
+        data: "WMATA bustime GPS archive (via markongithub/bus_data_archive) + WMATA GTFS/developer APIs",
+        pushed: "2019-09-12",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "dcfinancials",
+        url: "https://github.com/civictechdc/dcfinancials",
+        score: 3,
+        tier: "top",
+        stillGoUrl: "https://dcbudget.com/",
+        stillGoName: "dcbudget.com",
+        stillGo:
+          "DC has no open checkbook, just single-payment lookup, per-year purchase-order snapshots, and agency dashboards. dcbudget.com's structured exports cover one fiscal year at a time; the missing layer is multi-year analysis stitched across editions, which no tool attempts.",
+        theme: "Budget & Spending",
+        one: "A 2013 Code for DC hack project to parse DC government budget and spending data (agency POs, CBE contracts) into structured CSV/JSON for eventual analysis and visualization.",
+        problem:
+          "DC government budget and spending data (purchase orders, contract/vendor data, CBE certifications) was locked in inconsistent spreadsheets/PDFs, making it hard for the public or watchdogs to analyze how DC spends money or track certified business enterprise contracting.",
+        why: "Classic hack-day project: got as far as writing data parsers and exporting CSVs from raw spreadsheets, but never built the promised analysis/visualization layer and was abandoned after initial data-wrangling burst (no commits after June 2013).",
+        pitch:
+          "The parsing this repo attempted is now largely solved by dcbudget.com's structured per-deployment exports, and DC still has no open checkbook, only single-payment lookup and per-year purchase-order snapshots. What survives of the idea is the analysis layer: multi-year spending trends and cost tracking stitched across budget editions, which neither dcbudget.com, a single-year snapshot, nor any official tool attempts.",
+        maturity: "prototype",
+        tech: "JavaScript (parsing scripts) + raw Excel/CSV data files",
+        data: "DC Open Data (data.dc.gov) - DCFPI budget spreadsheets, CBE (Certified Business Enterprise) contract/PO data",
+        pushed: "2013-06-01",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "ERDA",
+        url: "https://github.com/civictechdc/ERDA",
+        score: 3,
+        tier: "top",
+        stillGoUrl: "https://fems.dc.gov/",
+        stillGoName: "FEMS",
+        stillGo:
+          "FEMS' neighborhood response-time maps are static FY2022 snapshots on a 300-meter grid, the performance page tops out at the FY24 plan, and OUC's 911 dashboard measures call answering, not unit arrival. The equity question, which blocks wait longest, is four years stale in official channels.",
+        theme: "Public Safety",
+        one: "A 2014 Code for DC project to statistically analyze DC's emergency response (fire/EMS dispatch) data and expose it via an API for visualizations.",
+        problem:
+          "DC's emergency response (911/EMS/fire) data was hard to access and analyze; the project wanted to clean, merge, and expose it so the public/researchers could understand response times and patterns.",
+        why: "A single hack-season project (2014) that lost momentum after the initial volunteer group moved on; reopened in 2026 when verification showed the official response-time products had gone stale.",
+        pitch:
+          "The Excel-sanitization era this repo fought is over, but the official replacements went stale: response-time equity analysis needs incident-level dispatch data joined to neighborhoods, and nothing current is published. A refreshed dashboard would be the only current view in the city. Confirm the incident-level data source on Open Data DC before building; if it has to come from FOIA, that is where this project stalls.",
+        maturity: "working",
+        tech: "Python (data cleaning scripts) + a separate API layer, published via GitHub Pages",
+        data: "DC emergency response (fire/EMS) dispatch data, sourced from DC government + Google Drive raw/preprocessed exports",
+        pushed: "2014-08-19",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "hospital-pricing",
+        url: "https://github.com/civictechdc/hospital-pricing",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://hospitalpricingfiles.org/",
+        supersededName: "Hospital pricing files",
+        superseded:
+          "Price-file aggregation is commodity now: Turquoise Health's free patient tool, PatientRightsAdvocate's file library, and Sage Transparency all cover it.",
+        theme: "Public Health",
+        one: "A bare data repository for manually collecting and standardizing DC-area hospital chargemaster/price-transparency files.",
+        problem:
+          "Hospital pricing is opaque and hard for patients/consumers to compare; standard charge files exist per-hospital but weren't aggregated or normalized anywhere in one place for DC.",
+        why: "Manual file collection is tedious and doesn't scale; no processing/normalization code was ever written to make the raw files useful, and the effort predates (by ~2 years) the federal price-transparency mandate that would have made this systematic.",
+        pitch:
+          "The core idea (aggregate and normalize hospital chargemaster data so patients/researchers can compare prices) is now federally mandated data (CMS hospital price transparency rule, effective 2021, requires standardized machine-readable files) so the hard part of getting hospitals to disclose has been solved by regulation - reviving this would mean writing a scraper/ETL pipeline against the now-standardized CMS files plus an LLM-assisted schema normalizer to handle inconsistent hospital formats, then a simple comparison UI; much more tractable in 2026 than manually downloading XLS/PDF files by hand.",
+        maturity: "idea-only",
+        tech: "None (data-only repo; raw CSV/XLS/XLSX/PDF/TSV files, no code)",
+        data: "Manually collected hospital billing/price transparency files (CSV/XLS/PDF) from individual DC-area hospitals",
+        pushed: "2019-01-29",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "LegiTrack",
+        url: "https://github.com/civictechdc/LegiTrack",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://lims.dccouncil.gov/",
+        supersededName: "LIMS",
+        superseded:
+          "The Council's LIMS covers bills and member voting records back to 1989, updated daily, with a public API.",
+        theme: "Regulations & Legislation",
+        one: "A front-end tracker for DC Council bills and council-member votes, built as a Middleman/Ruby static site.",
+        problem:
+          "DC residents have no easy way to see what bills the DC Council is considering or how council members voted on them.",
+        why: "Classic hack-day project — appears to be a single weekend/short sprint effort (5 commits, one month of activity) that never got backend/data integration, deployment, or user features finished before being abandoned.",
+        pitch:
+          "The core idea — a clean, searchable \"how did my council member vote\" tracker — is still exactly what DC civic engagement needs and there's still no great public tool for it. Today this is far easier: DC Council's own LIMS/legislative data plus an LLM to summarize bill text and generate plain-language vote explainers could turn this from a static hack-day mockup into a real living site in a weekend, hosted free on Vercel/Cloudflare Pages.",
+        maturity: "prototype",
+        tech: "Ruby (Middleman static site generator) + CSS/JS",
+        data: "DC Council legislative data (bills/votes) — source unspecified in README",
+        pushed: "2016-02-02",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "opendatadc",
+        url: "https://github.com/civictechdc/opendatadc",
+        site: "/projects/opendatadc.html",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://opendata.dc.gov/",
+        supersededName: "Open Data DC",
+        superseded:
+          "The official portal serves the catalog role. The remaining gap, roughly a quarter of non-sensitive datasets unpublished, is an advocacy fight, not a rebuild.",
+        theme: "Regulations & Legislation",
+        one: "A community-run open data portal (data.codefordc.org) built on CKAN, intended as a broader/complementary alternative to the DC government's official Open Data DC portal.",
+        problem:
+          "DC lacked an independent, broader-scope open data hub not bound by government data-collection mandates — a place for volunteer-curated datasets, analysis, and teaching resources for residents/researchers who want data the official DC government portal doesn't carry or present well.",
+        why: "Unclear — likely maintainer bandwidth/CKAN operational overhead; CKAN deployments are heavy (docker-compose stack with Solr, Postgres, nginx, datapusher) for a volunteer org to sustain long-term, and DC government's own Open Data DC portal likely reduced the unique value proposition over time.",
+        pitch:
+          'The CKAN-hosting-and-curation model is now much easier to run cheaply (managed CKAN hosting, or swap to a lightweight modern stack like Datasette/DuckDB + static site, and use LLMs to auto-generate dataset descriptions/etl scripts). The real reusable idea is the "three streams" volunteer structure (portal, analysis, stakeholder-matching) plus the ANC-level turnout-estimation R work already in the repo — a modern revival could rebuild it as a lightweight Datasette-based portal with LLM-assisted data cleaning/cataloging, resurrecting the civic-analysis pipeline (e.g., ANC turnout, precinct data) with far less infra overhead than CKAN required.',
+        maturity: "deployed",
+        tech: "JavaScript/Python (CKAN extension) with R analysis scripts (Shiny app)",
+        data: "DC Open Data portal (CKAN), plus ad-hoc datasets from DC govt and other sources",
+        pushed: "2020-02-19",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "school-modernization",
+        url: "https://github.com/civictechdc/school-modernization",
+        score: 3,
+        tier: "top",
+        stillGoUrl:
+          "https://edscape.dc.gov/page/dcps-public-school-facility-modernizations",
+        stillGoName: "Edscape map",
+        stillGo:
+          "DME's Edscape map shows which schools are modernized and when, but publishes no dollar amounts, so the equity-spending question remains unanswerable. The dollars exist in CIP PDFs and dcbudget.com's export; the join is the whole build.",
+        theme: "Budget & Spending",
+        one: "A data viz project mapping 15 years (~$5B) of DCPS school facilities modernization spending by school/neighborhood to reveal equity gaps in fund distribution",
+        problem:
+          "DCPS ran a ~15-year, ~$5B facilities modernization program; spending data existed but wasn't legible, making it hard to tell whether upgrades were distributed equitably across neighborhoods/schools ahead of council budget hearings",
+        why: "Likely a volunteer project tied to a specific public-hearing timeline; once that legislative moment passed, momentum and maintenance stopped (last push July 2016).",
+        pitch:
+          "DME's official Edscape map now shows which schools are modernized and when, through FY31, and even publishes the ward-equity framing. But it shows no dollar amounts, so the original equity-spending question is still unanswerable. The remaining build is joining CIP cost data to the official map's timeline.",
+        maturity: "prototype",
+        tech: "HTML/JS (d3.js) with R data-processing scripts",
+        data: "DCPS/PCSB/OSSE/OCFO facilities spending data (input/output CSVs in repo)",
+        pushed: "2016-07-21",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "the-rat-hack",
+        url: "https://github.com/civictechdc/the-rat-hack",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://dchealth.dc.gov/rodent-control-dashboard",
+        supersededName: "Rodent Control Dashboard",
+        superseded:
+          "DC Health launched an official rodent-control dashboard in July 2026: complaint hotspots, seasonal trends, ward-level treatment counts.",
+        theme: "Public Health",
+        one: "A 2017-18 Code for DC hack project analyzing DC 311 rodent-complaint data to predict rat outbreak trends and feed a public 311 data portal.",
+        problem:
+          'DC was ranked among the "rattiest" cities in America; the city wanted to predict rodent-complaint upticks in space/time to support Mayor Bowser\'s "Rat Riddance" initiative and complement OCTO\'s own modeling.',
+        why: 'Typical hack-day project: activity concentrated in 2017-2018 (feature engineering PRs), then went quiet after April 2018 pushdate; no further commits, likely lost momentum after initial contributors moved on and no clear "deployed" outcome documented in this repo.',
+        pitch:
+          "DC 311 data is now far richer and easier to pull (Open Data DC APIs), and modern time-series/spatial libraries (or an LLM-assisted feature pipeline) make the predictive modeling this project attempted in R trivial to redo in Python with a proper dashboard (e.g. a lightweight geospatial heatmap + trend forecast) instead of a Docker+RStudio onboarding flow.",
+        maturity: "prototype",
+        tech: "R (RStudio/Docker), companion 311 data portal (separate repo/site)",
+        data: "DC 311 service request data (OCTO); Dropbox export",
+        pushed: "2018-04-12",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "us-congress-pizza-flag-tracker",
+        url: "https://github.com/civictechdc/us-congress-pizza-flag-tracker",
+        score: 3,
+        tier: "superseded",
+        supersededUrl:
+          "https://www.aoc.gov/what-we-do/programs-ceremonies/capitol-flag-program",
+        supersededName: "Capitol Flag Program",
+        superseded:
+          "The House runs its own system: FlagTrack at flagorder.house.gov (staff-facing), with FlagTrack 2.0 funded in March 2026 to add constituent-facing tracking across order, fly, shipping, and delivery dates. An outside tracker would duplicate a funded official build with no data access.",
+        theme: "Org Infrastructure",
+        one: "A tracker for the U.S. Capitol's flag-flying request/fulfillment process, built with congressional staff (Modernization Staff Association) to manage constituent flag orders.",
+        problem:
+          "Congressional offices field constituent requests to have a flag flown over the U.S. Capitol (a common constituent-service perk); tracking and fulfilling these requests was apparently a manual/ad-hoc process this tool aimed to systematize with an order-management workflow (statuses like archived/cancelled/uncancelled).",
+        why: "unclear — no commits since Oct 2022; likely lost core volunteers post-pandemic Code for DC wind-down rather than any technical failure, since the project was clearly functional and had staff buy-in.",
+        pitch:
+          "A working order-management tool for a real, recurring congressional constituent-service workflow, built with an actual congressional staff partner (Modernization Staff Association), is rare in civic tech — most projects never land a government partner. If flag requests are still handled manually in some offices, this could be revived as a lightweight internal tool; modern form-intake tooling and LLM-assisted status tracking could replace much of the custom React frontend.",
+        maturity: "deployed",
+        tech: "Python/Flask backend + React/TypeScript frontend, Postgres/SQLite",
+        data: "none (manual/staff-submitted flag order data)",
+        pushed: "2022-10-12",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "congressional-tech",
+        url: "https://github.com/civictechdc/congressional-tech",
+        site: "/projects/congressional-tech.html",
+        score: 5,
+        tier: "active",
+        theme: "Regulations & Legislation",
+        one: "A portfolio/monorepo of civic-tech tools to make congressional operations and data (hearings, committee video, appropriations, CRS/GAO reports, schedules) more accessible and efficient, several with AI-powered analysis.",
+        problem:
+          "Congressional data and operations (hearing/markup records, committee YouTube archives, appropriations documents, CRS/GAO reports, floor schedules, job postings) are scattered, unstructured, and hard for staff, journalists, and the public to use; the repo catalogs ~18 discrete tool ideas across accessibility, workflow efficiency, AI content enhancement, and predictive analytics for legislative data.",
+        why: 'Not stalled -- actively maintained as of Feb 2026 with ongoing commits and multiple contributors; some sub-projects within the portfolio (predictive/analytical tools in section IV) remain unscoped ("not set" level of effort) and unbuilt.',
+        pitch:
+          'This is not stalled -- it\'s a live, well-organized backlog of congressional-tech ideas already prioritized by level of effort, with a working monorepo and active contributors. Anyone wanting to "revive" an idea here should instead just pick up one of the un-started items directly from the project list (e.g. Bill Delay Tracker, Witness Database with testimony summarization, CRS/GAO report AI transformation) -- modern LLMs make the AI-heavy items (newsletter generation, transcript summarization, report transformation) far more tractable now than when first scoped.',
+        maturity: "deployed",
+        tech: "TypeScript (Next.js) + Python monorepo (turborepo, devcontainer)",
+        data: "Congress.gov, committee YouTube channels, CRS/GAO reports, GovTrack",
+        pushed: "2026-02-08",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "DMVWaterWatch",
+        url: "https://github.com/civictechdc/DMVWaterWatch",
+        site: "/projects/watervoice-dmv.html",
+        score: 5,
+        tier: "active",
+        theme: "Environment & Energy",
+        one: 'A mobile-first map giving paddlers, rowers, and swimmers a traffic-light "is it safe to get in the water today" report card for ~34 inner-DMV recreation sites.',
+        problem:
+          'Water-quality/safety data for DMV rivers (bacterial sampling, streamflow, rainfall, impairment status) is real but scattered across PDFs, dashboards, and dormant Water Reporter embeds, with no single consumer-facing answer to "can I safely paddle/swim here today."',
+        why: "Not stalled — a young project with continuous progress; the open items are external (data-partner outreach, API tokens, legal review) rather than signs of abandonment.",
+        pitch:
+          "This isn't really a graveyard candidate yet — it's an actively developed, well-architected MVP (real APIs wired, tested grading rubric, deploy-ready) that just needs the remaining outreach/access items (Swim Guide token, DOEE EQuIS access, legal review) and a Cloudflare Pages deploy to go live. If it stalls, the highest-value revival move is simply finishing Phase 6: get the two remaining data partnerships and ship it, since the hard engineering work (connector architecture, grading logic, UI, tests) is already done.",
+        maturity: "working",
+        tech: "TypeScript / Next.js 16 + React 19 + MapLibre",
+        data: "USGS NWIS, USGS Water Quality Portal, NOAA precip/tides, EPA How's My Waterway, plus Anacostia Riverkeeper and DC DOEE sonde data (fixture-backed pending real feeds)",
+        pushed: "2026-05-19",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "spicy-regs",
+        url: "https://github.com/civictechdc/spicy-regs",
+        site: "/projects/spicyregs.html",
+        score: 5,
+        tier: "active",
+        theme: "Regulations & Legislation",
+        one: "An open, contributor-friendly ETL and analysis platform for regulations.gov and adjacent federal rulemaking/lobbying data, exposed as downloadable Parquet, a Claude/MCP tool, and a hosted docs/app site.",
+        problem:
+          "Federal regulatory data (dockets, comments, rulemaking) is scattered across regulations.gov, agency-specific systems (FCC ECFS), and related transparency datasets (Federal Register, Congress.gov, FEC, lobbying, spending, courts), locked in inconsistent raw JSON with no easy, reproducible way for technical or non-technical people to explore it.",
+        why: "Not stalled — actively developed and shipping. A live flagship Civic Tech DC project, listed here only for completeness.",
+        pitch:
+          'No revival needed — this is the project other stalled regulatory-data ideas in the graveyard should be pointed toward as a model/merge target. Anyone with an old "regs.gov scraper" or "public comment analysis" idea in the archive should be redirected here rather than restarting from scratch.',
+        maturity: "deployed",
+        tech: "Python (uv, DuckDB, Parquet), Jupyter Notebook (primary language per GitHub), Vercel-hosted MCP server, mkdocs",
+        data: "regulations.gov (via Mirrulations mirror), plus FCC ECFS, Federal Register, Congress.gov, FEC, LDA, SAM.gov, USASpending, CourtListener, GAO/CRS",
+        pushed: "2026-07-23",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "ballot-sign",
+        url: "https://github.com/civictechdc/ballot-sign",
+        incubator: true,
+        score: 4,
+        tier: "superseded",
+        supersededUrl:
+          "https://code.dccouncil.gov/us/dc/council/code/sections/1-1001.16",
+        supersededName: "DC Code 1-1001.16",
+        superseded:
+          "Blocked by statute, not by a competing product: DC Code 1-1001.16 requires circulators to witness each signature in person and file completed petition sheets in hard copy, and DCBOE's own 2015 eSign pilot is dead. Digital signing needs the Council to amend the election code first, which makes this advocacy, not software.",
+        theme: "Elections, ANC & Voting",
+        one: "A proposed open-source, legally-compliant digital platform for discovering and signing DC ballot initiative petitions, replacing door-to-door canvassing.",
+        problem:
+          "DC ballot initiative campaigns rely on inefficient, costly door-to-door canvassing to collect signatures, and residents have limited awareness of active initiatives; signature collection also must be securely recorded per DC election law.",
+        why: "A project team never assembled at the January 2026 meetings; no legal, architectural, or technical work began beyond the intent statement. The repository has been archived.",
+        pitch:
+          "The concept (discover + digitally sign + securely record ballot-initiative signatures within DC election law) is still compelling civic infrastructure, but this repo never got past the intent-statement stage — a revival would start from zero: legal research on DC's e-signature/petition requirements, a look at existing open-source petition/e-signature platforms, and a real architecture/security design before any code. Modern identity-verification and e-signature tooling (and LLM-assisted legal research) make the feasibility study much cheaper to do now than in 2025.",
+        maturity: "idea-only",
+        tech: "none (no code, no primaryLanguage)",
+        data: "none",
+        pushed: "2026-01-15",
+        arch: true,
+        relevant: true,
+      },
+      {
+        name: "cib-mango-tree",
+        url: "https://github.com/civictechdc/cib-mango-tree",
+        site: "/projects/cib-mango-tree.html",
+        score: 4,
+        tier: "active",
+        theme: "Misc / Civic Data",
+        one: "An open-source Python toolkit (with a desktop GUI) for detecting coordinated inauthentic behavior (CIB) in datasets of online/social media activity.",
+        problem:
+          "Researchers, data journalists, fact-checkers, and watchdogs need an accessible way to detect coordinated inauthentic behavior (bot networks, astroturfing, copy-paste campaigns) in social media data without building custom NLP/network-analysis pipelines from scratch.",
+        why: "Not stalled — actively developed as of July 2026, with recent performance overhauls and a new GUI release.",
+        pitch:
+          'No revival needed — this is a healthy, ongoing project and a good model for what "graduated" Civic Tech DC work looks like (went from terminal UI to full GUI, has a real analyzer pipeline with n-gram/ngram-coordination detection, emoji/script-based text normalization, and parallel Polars-based processing). If listing it at all, frame it as a success story / flagship rather than a dormant idea; anyone interested in CIB detection should just contribute to it directly rather than reinvent it.',
+        maturity: "deployed",
+        tech: "Python (Polars, PyInstaller for packaging, GUI framework), MIT licensed",
+        data: "Social media datasets (user-provided, e.g. Twitter/X exports, CSVs of posts)",
+        pushed: "2026-07-20",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "congress_meeting_map",
+        url: "https://github.com/civictechdc/congress_meeting_map",
+        site: "/projects/congressional-tech.html",
+        score: 4,
+        tier: "active",
+        theme: "Misc / Civic Data",
+        one: "An interactive force-directed knowledge-graph explorer that turns congressional hackathon breakout-session discussions (transcripts/comments) into a browsable visual map of themes, ideas, threads, and comments.",
+        problem:
+          "Congressional modernization hackathon/committee breakout discussions produce rich unstructured conversation (ideas, threads, comments) that's hard to review or make sense of after the fact — no good way to explore what was actually discussed, which themes connected, or which ideas got the most engagement.",
+        why: "Not really stalled — built and shipped Sept 2025 as a single-event artifact (one hackathon's discussions); likely just completed its scope rather than being abandoned, with no indication of follow-on generalization work planned.",
+        pitch:
+          'The concept generalizes well beyond one hackathon: any meeting/summit/testimony corpus (town halls, agency listening sessions, public comment periods) could be turned into the same force-directed explorer. With modern LLMs, the manual Gemini/ChatGPT data-shaping step here could be automated into a repeatable pipeline (transcript -> clusters/ideas/threads/comments JSON-LD -> graph), turning this from a one-off single-event visualization into a reusable "meeting insight explorer" tool for civic engagement data generally.',
+        maturity: "deployed",
+        tech: "TypeScript / React + Vite + D3.js + Tailwind + Zustand + Framer Motion",
+        data: "Congressional hackathon breakout session transcripts (audio/comments), converted to JSON-LD",
+        pushed: "2025-09-20",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "dc-campaign-finance-scraper",
+        url: "https://github.com/civictechdc/dc-campaign-finance-scraper",
+        incubator: true,
+        score: 4,
+        tier: "active",
+        theme: "Elections, ANC & Voting",
+        one: "A Python CLI + library that scrapes DC's Office of Campaign Finance donation/expenditure search tool and outputs clean structured data (CSV/JSON/YAML/xlsx/html).",
+        problem:
+          "DC's official campaign finance data was only accessible through a clunky ASP.NET form-based download tool on ocf.dc.gov with no real API, making it hard to analyze who funds DC political campaigns.",
+        why: "Not stalled — actively maintained, last pushed April 2026.",
+        pitch:
+          "DC campaign finance transparency is evergreen and this repo already solved the hard part (session/cookie handling, office/candidate matching heuristics). Revive by swapping the fragile ASP scraping for whatever DC OCF's current data portal/API is (likely modernized since 2014), adding a scheduled scrape-to-database pipeline, and layering an LLM-assisted contributor/employer normalization pass (the original code had to guess office/election-year from committee name - an LLM could do this far more reliably than 2014-era heuristics) plus a simple public dashboard for donor search.",
+        maturity: "working",
+        tech: "Python (Click CLI, Requests, setup.py/PyPI package)",
+        data: "DC Office of Campaign Finance (ocf.dc.gov/serv/download.asp)",
+        pushed: "2026-04-13",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "repower-dmv-extractor",
+        url: "https://github.com/civictechdc/repower-dmv-extractor",
+        score: 4,
+        tier: "superseded",
+        supersededUrl: "https://contractors.electrifydc.org/",
+        supersededName: "Electrify DC contractor finder",
+        superseded:
+          "Electrify DC runs a live, vetted contractor finder and hosts an Electrify DMV network page, backed by DCSEU rebates and DOEE programs.",
+        theme: "Housing & Tenant Rights",
+        one: "A TypeScript CLI pipeline that extracts, cross-references, and fuzzy-matches contractor records to build a clean dataset of DMV-area businesses that do home-efficiency/electrification work.",
+        problem:
+          "DC-area residents need a trustworthy, up-to-date list of legitimate contractors who do home-efficiency and electrification work (insulation, heat pumps, etc.), matched against official licensing data so scam/unlicensed operators can be filtered out.",
+        why: "The ElectrifyDMV partnership ended for lack of sustained project leadership; the extraction pipeline never got a public destination.",
+        pitch:
+          "DC residents still have no easy, trustworthy directory of vetted home-efficiency/electrification contractors, and utility rebate/DOEE programs keep changing - this pipeline already solves the hard data-matching problem (license registry + Google Places fuzzy dedupe). Revive it by scheduling the extract/transform run periodically, adding an LLM-based reviewer for messy source records, and shipping the output as a simple searchable site (e.g. static site + Cloudflare D1) - the backend is basically done.",
+        maturity: "working",
+        tech: "TypeScript / Node (CLI via commander, axios, fuzzball, csv, winston)",
+        data: "DC contractor/business license registry + Google Places API",
+        pushed: "2025-07-28",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "ridescoredc",
+        url: "https://github.com/civictechdc/ridescoredc",
+        site: "/projects/ridescoredc.html",
+        score: 4,
+        tier: "active",
+        theme: "Transit & Mobility",
+        one: "A community pipeline and map to score DC streets for bike safety/comfort by combining open data (crashes, lane counts, speed) with transparent rulesets like Level of Traffic Stress (LTS) and BNA-style connectivity.",
+        problem:
+          "DC has no single, transparent, data-driven way to see which streets are actually safe/comfortable to bike on — existing bike-safety framing is scattered across agency data (crashes, lane counts, speed limits) with no unified public score or map.",
+        why: "Active but early — the architecture is well-specified in the README while the implementation is still thin; progress tracks available volunteer bandwidth.",
+        pitch:
+          "The concept (transparent, rules-based bike comfort scoring a la LTS/BNA, rendered as an interactive map) is exactly the kind of thing that's much easier now: DC's open data (crash, lane, ADT/speed) is more complete than in 2015-era hack projects, OSM tagging for DC streets has improved, and an LLM can quickly help encode/validate LTS-style rulesets and generate the ingest/scoring pipeline that the README already sketches but never got built — someone could plausibly turn the existing README architecture into a working v1 in a weekend using Claude Code plus a Leaflet/MapLibre frontend.",
+        maturity: "prototype",
+        tech: "Jupyter Notebook / Python (planned), Leaflet/MapLibre web map",
+        data: "DC Open Data / OSM (roads, lanes, speed, crashes) — per README, not yet actually ingested in visible code",
+        pushed: "2026-03-09",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "votecatcher",
+        url: "https://github.com/civictechdc/votecatcher",
+        site: "/projects/ballot-initiative.html",
+        score: 4,
+        tier: "active",
+        theme: "Elections, ANC & Voting",
+        one: "Open-source campaign infrastructure that automates OCR/recognition and validation of ballot petition signatures for grassroots ballot-initiative campaigns.",
+        problem:
+          "Grassroots ballot-initiative campaigns need to collect and validate large volumes of voter signatures on paper petitions to qualify for the ballot; manual signature verification/matching is slow and labor-intensive for volunteer-run campaigns.",
+        why: "Not stalled - an active, currently-maintained project (commits and CI activity as recent as the scan date). It continues the earlier Ballot-Initiative petition-verification project under a new name.",
+        pitch:
+          "This one doesn't need reviving - it's live and actively maintained today, tied to CivicTechDC's ballot-initiative project page, with LLM-based OCR (OpenAI/Mistral/Gemini) already integrated for signature recognition, a simulation mode for contributors without API keys, and multiple one-click cloud deploy paths. Anyone interested in ballot-access/organizing tech should just join the existing #vote_catcher Slack channel and contribute rather than starting fresh - the hard infrastructure (job queue, OCR pipeline, auth, multi-DB support) is already built.",
+        maturity: "working",
+        tech: "Python (FastAPI/SQLModel) backend + SvelteKit 5/TypeScript frontend",
+        data: "none",
+        pushed: "2026-07-24",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "eavs_clc",
+        url: "https://github.com/civictechdc/eavs_clc",
+        site: "/projects/data-and-democracy.html",
+        score: 3,
+        tier: "active",
+        theme: "Elections, ANC & Voting",
+        one: "Pipeline to download and clean the U.S. Election Administration and Voting Survey (EAVS) dataset for Campaign Legal Center's Voting Rights team research.",
+        problem:
+          "EAVS is a huge, messy biennial federal survey (about 400 cryptically-coded columns, about 6000 rows) on how U.S. elections are administered; making it usable for voting-rights research and longitudinal analysis requires nontrivial download, clean, and decode tooling that did not otherwise exist in an accessible form.",
+        why: "Not stalled. This is an active, ongoing Civic Tech DC project built for and with an external partner (Campaign Legal Center), still receiving feature PRs as of Feb 2026.",
+        pitch:
+          "Not really a revival candidate since it is alive and working, but the reusable pattern is strong: a clean, checksum-verified ETL pipeline for a gnarly government dataset (coded columns, biennial releases, inconsistent schemas across years) paired with a real external stakeholder (Campaign Legal Center) consuming the output. Other civic-data pipelines (EAC, FEC, Census-style surveys) could fork this template directly.",
+        maturity: "working",
+        tech: "Python (uv, pandas, calamine, ruff, just)",
+        data: "EAC Election Administration and Voting Survey (EAVS), eac.gov",
+        pushed: "2026-02-25",
+        arch: false,
+        relevant: true,
+      },
+      {
+        name: "repower-dmv",
+        url: "https://github.com/civictechdc/repower-dmv",
+        score: 3,
+        tier: "superseded",
+        supersededUrl: "https://contractors.electrifydc.org/",
+        supersededName: "Electrify DC contractor finder",
+        superseded:
+          "Electrify DC runs a live, vetted contractor finder and hosts an Electrify DMV network page, backed by DCSEU rebates and DOEE programs.",
+        theme: "Environment & Energy",
+        one: "ElectrifyDC (repo repower-dmv) — a Remix/TypeScript website helping DC residents find info and contractors for home electrification (e.g. heat pumps, induction stoves).",
+        problem:
+          "DC residents lack an easy way to learn about home electrification incentives/programs and find vetted local contractors to do heat pump/induction stove/electrical panel upgrades.",
+        why: "The ElectrifyDMV partnership ended for lack of sustained project leadership.",
+        pitch:
+          "The contractor-directory + CMS-driven content model is solid and was already validated enough to get embedded into a partner WordPress site for a grant — the underlying idea (connect residents to electrification programs/contractors) is more relevant now given IRA rebates and rising DC electrification incentives. A revival could add an LLM-based eligibility/rebate-matching assistant on top of the existing contractor data model, and modernize by dropping the custom Decap-CMS/iframe embed pattern for a simpler headless CMS or static site generator.",
+        maturity: "deployed",
+        tech: "TypeScript (Remix, Prisma/SQLite, Tailwind, Docker/Fly.io)",
+        data: "Decap-CMS managed content + contractor directory (no external gov dataset evident)",
+        pushed: "2025-10-29",
+        arch: false,
+        relevant: true,
+      },
+    ];
 
-      // counts (computed from DATA so they can never drift)
-      const countOf = (t) => DATA.filter((d) => d.tier === t).length;
-      document.getElementById("stat-all").textContent = DATA.length;
-      document.getElementById("stat-top").textContent = countOf("top");
-      document.getElementById("stat-active").textContent = countOf("active");
-
-      let activeTier = "all",
-        query = "";
-      const chips = [...document.querySelectorAll(".tab")];
-      chips.forEach((c) => {
-        const t = c.dataset.t;
-        const n = t === "all" ? DATA.length : countOf(t);
-        c.querySelector(".ct").textContent = n || "";
+    var GROUPS = [
+      {
+        id: "top",
+        label: "Worth reviving",
+        sub: "Dead or dormant, still relevant in 2026. Start here.",
+      },
+      {
+        id: "active",
+        label: "Still alive — go contribute",
+        sub: "Pushed within the last year. Join these rather than rebuild them.",
+      },
+      {
+        id: "superseded",
+        label: "Superseded — case closed",
+        sub: "An August 2026 scan found the need now served by an official or maintained public tool. Each file records what replaced it, so nobody rebuilds these.",
+      },
+      {
+        id: "proposed",
+        label: "Proposed — the empty drawer",
+        sub: "Ideas that don't exist yet. Pitch one and it gets a folder.",
+      },
+    ];
+    var STAMP = { top: "Revive", active: "Active", superseded: "Superseded" };
+    var esc = function (s) {
+      return String(s).replace(/[&<>"]/g, function (c) {
+        return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
       });
-      const empty = document.getElementById("empty");
+    };
+    var root = document.getElementById("archive-dig-root");
+    // keep the drawer rail clear of the sticky site header at any viewport
+    var siteHeader = document.querySelector(".ctdc-header");
+    function setHeaderOffset() {
+      if (siteHeader) {
+        root.style.setProperty(
+          "--ad-header-offset",
+          Math.round(siteHeader.getBoundingClientRect().height) + "px",
+        );
+      }
+    }
+    setHeaderOffset();
+    window.addEventListener("resize", setHeaderOffset);
+    var cardsHost = document.getElementById("ad-cards");
 
-      function applyFilter() {
-        let shown = 0;
-        document.querySelectorAll(".group").forEach((sec) => {
-          const gid = sec.dataset.group;
-          let vis = 0;
-          sec.querySelectorAll("[data-tier]").forEach((c) => {
-            const okTier =
-              activeTier === "all" || c.dataset.tier === activeTier;
-            const okQ = !query || (c.dataset.text || "").includes(query);
-            const show = okTier && okQ;
-            c.style.display = show ? "" : "none";
-            if (show) vis++;
-          });
-          const tierMatch = activeTier === "all" || gid === activeTier;
+    function noteBlock(d) {
+      var out = "";
+      if (d.superseded) {
+        out +=
+          '<p class="sup-note"><span class="k">Superseded</span>' +
+          esc(d.superseded) +
+          (d.supersededUrl
+            ? ' <a href="' +
+              d.supersededUrl +
+              '" target="_blank" rel="noopener">' +
+              esc(d.supersededName) +
+              " &#8599;</a>"
+            : "") +
+          '<span class="note-when">Aug 2026</span></p>';
+      }
+      if (d.stillGo) {
+        out +=
+          '<p class="go-note"><span class="k">Still open</span>' +
+          esc(d.stillGo) +
+          (d.stillGoUrl
+            ? ' <a href="' +
+              d.stillGoUrl +
+              '" target="_blank" rel="noopener">' +
+              esc(d.stillGoName) +
+              " &#8599;</a>"
+            : "") +
+          '<span class="note-when">Aug 2026</span></p>';
+      }
+      return out;
+    }
+
+    function card(d) {
+      var dataline =
+        d.data && !["none", "n/a", ""].includes(String(d.data).toLowerCase())
+          ? '<div class="row"><span class="k">Data source</span>' +
+            esc(d.data) +
+            "</div>"
+          : "";
+      var filelinks =
+        d.tier === "active" || d.site
+          ? '<div class="filelinks"><a href="' +
+            d.url +
+            '" target="_blank" rel="noopener" data-analytics-event="project_repository_click" data-analytics-location="archive_card">GitHub &#8599;</a>' +
+            (d.site
+              ? '<a href="' +
+                d.site +
+                '" data-analytics-event="project_discovery_click" data-analytics-location="archive_card">Project page &#8599;</a>'
+              : "") +
+            "</div>"
+          : "";
+      var pitchRow = d.superseded
+        ? ""
+        : '<div class="row pitch"><span class="k">Revival pitch</span>' +
+          esc(d.pitch) +
+          "</div>";
+      var text = (
+        d.name +
+        " " +
+        d.one +
+        " " +
+        d.theme +
+        " " +
+        d.tech +
+        " " +
+        d.pitch +
+        " " +
+        d.problem +
+        " " +
+        (d.superseded || "") +
+        " " +
+        (d.stillGo || "")
+      ).toLowerCase();
+      return (
+        '<article class="card t-' +
+        d.tier +
+        '" data-tier="' +
+        d.tier +
+        '" data-text="' +
+        esc(text) +
+        '">' +
+        '<span class="folder-tab">' +
+        esc(d.theme) +
+        "</span>" +
+        '<div class="card-body">' +
+        '<div class="card-top"><div><a class="repo" href="' +
+        d.url +
+        '" target="_blank" rel="noopener">' +
+        esc(d.name) +
+        "</a></div>" +
+        '<span class="stamp">' +
+        (STAMP[d.tier] || esc(d.tier)) +
+        "</span></div>" +
+        '<div class="meta-row"><span>' +
+        esc(d.maturity) +
+        "</span><span>pushed " +
+        esc(d.pushed) +
+        "</span>" +
+        (d.arch ? '<span class="arch">archived</span>' : "") +
+        (d.incubator ? '<span class="incub">incubator</span>' : "") +
+        "</div>" +
+        '<p class="one">' +
+        esc(d.one) +
+        "</p>" +
+        noteBlock(d) +
+        filelinks +
+        '<details><summary><span class="caret">›</span>Open the file</summary>' +
+        '<div class="detail-block">' +
+        pitchRow +
+        '<div class="row"><span class="k">Problem it solved</span>' +
+        esc(d.problem) +
+        "</div>" +
+        '<div class="row"><span class="k">Why it stalled</span>' +
+        esc(d.why) +
+        "</div>" +
+        dataline +
+        '<div class="detail-meta"><span class="tag">' +
+        esc(d.tech) +
+        "</span></div>" +
+        "</div></details></div></article>"
+      );
+    }
+
+    var PROPOSE_CARD =
+      '<div class="propose-card" data-tier="proposed" data-text="propose new idea pitch project night slack">' +
+      "<h3>This folder is empty</h3>" +
+      "<p>Have a civic idea worth building? Pitch it at a project night or start a thread in Slack. If it finds legs, it gets filed here — with your name on it.</p>" +
+      '<div class="propose-actions">' +
+      '<a href="/events" data-analytics-event="event_discovery_click" data-analytics-location="archive_propose">Pitch at a project night</a>' +
+      '<a href="/slack" data-analytics-event="slack_discovery_click" data-analytics-location="archive_propose">Start a thread in Slack</a>' +
+      "</div></div>";
+
+    function render() {
+      cardsHost.innerHTML = GROUPS.map(function (g) {
+        var items = DATA.filter(function (d) {
+          return d.tier === g.id;
+        });
+        var body = items.length
+          ? '<div class="grid">' + items.map(card).join("") + "</div>"
+          : PROPOSE_CARD;
+        var count = items.length ? items.length : "";
+        return (
+          '<section class="group" data-group="' +
+          g.id +
+          '"><div class="group-head"><h2>' +
+          g.label +
+          '</h2><span class="gcount">' +
+          count +
+          "</span></div>" +
+          '<p class="group-sub">' +
+          g.sub +
+          "</p>" +
+          body +
+          "</section>"
+        );
+      }).join("");
+    }
+    render();
+
+    var countOf = function (t) {
+      return DATA.filter(function (d) {
+        return d.tier === t;
+      }).length;
+    };
+    document.getElementById("stat-all").textContent = DATA.length;
+    document.getElementById("stat-top").textContent = countOf("top");
+    document.getElementById("stat-active").textContent = countOf("active");
+
+    var activeTier = "all";
+    var query = "";
+    var chips = Array.prototype.slice.call(root.querySelectorAll(".ad-tab"));
+    chips.forEach(function (c) {
+      var t = c.getAttribute("data-t");
+      var n = t === "all" ? DATA.length : countOf(t);
+      c.querySelector(".ct").textContent = n || "";
+    });
+    var empty = document.getElementById("ad-empty");
+
+    function applyFilter() {
+      var shown = 0;
+      Array.prototype.forEach.call(
+        root.querySelectorAll(".group"),
+        function (sec) {
+          var gid = sec.getAttribute("data-group");
+          var vis = 0;
+          Array.prototype.forEach.call(
+            sec.querySelectorAll("[data-tier]"),
+            function (c) {
+              var okTier =
+                activeTier === "all" ||
+                c.getAttribute("data-tier") === activeTier;
+              var okQ =
+                !query ||
+                (c.getAttribute("data-text") || "").indexOf(query) !== -1;
+              var show = okTier && okQ;
+              c.style.display = show ? "" : "none";
+              if (show) vis++;
+            },
+          );
+          var tierMatch = activeTier === "all" || gid === activeTier;
           sec.style.display = tierMatch && vis > 0 ? "" : "none";
           if (tierMatch) shown += vis;
-        });
-        empty.style.display = shown ? "none" : "block";
-      }
-
-      chips.forEach((c) =>
-        c.addEventListener("click", () => {
-          activeTier = c.dataset.t;
-          chips.forEach((x) =>
-            x.setAttribute("aria-pressed", x === c ? "true" : "false"),
-          );
-          applyFilter();
-        }),
+        },
       );
-      document.getElementById("q").addEventListener("input", (e) => {
-        query = e.target.value.trim().toLowerCase();
+      empty.style.display = shown ? "none" : "block";
+    }
+
+    chips.forEach(function (c) {
+      c.addEventListener("click", function () {
+        activeTier = c.getAttribute("data-t");
+        chips.forEach(function (x) {
+          x.setAttribute("aria-pressed", x === c ? "true" : "false");
+        });
         applyFilter();
       });
-    </script>
-  </body>
-</html>
+    });
+    document.getElementById("ad-q").addEventListener("input", function (e) {
+      query = e.target.value.trim().toLowerCase();
+      applyFilter();
+    });
+  })();
+</script>

--- a/projects.md
+++ b/projects.md
@@ -103,6 +103,11 @@ Since its founding in 2012, Civic Tech DC has worked on dozens of projects. This
 
 {% include components/project-cards.html is_active=false heading=3 columns=4 %}
 
+Looking for deeper history, or an idea to pick up? The
+[Ideas Graveyard]({{ site.baseurl }}/archive-dig/){: data-analytics-event="project_discovery_click" data-analytics-location="projects_archive"}
+catalogs 13 years of project files: dormant ideas verified as still worth
+reviving, and superseded ones with a record of what replaced them.
+
 </div>
 
 {% include components/content-review.html %}

--- a/scripts/check-seo-test.rb
+++ b/scripts/check-seo-test.rb
@@ -54,7 +54,8 @@ class CheckSeoHelpersTest < Minitest::Test
     assert_nil refresh_target(blank)
   end
 
-  def test_unlisted_pages_are_declared
-    assert_includes UNLISTED_PAGES, "archive-dig/index.html"
+  def test_unlisted_pages_is_a_frozen_list
+    assert_kind_of Array, UNLISTED_PAGES
+    assert_predicate UNLISTED_PAGES, :frozen?
   end
 end

--- a/scripts/check-seo.rb
+++ b/scripts/check-seo.rb
@@ -49,9 +49,7 @@ PROMOTED_CASE_STUDY_PROJECTS = %w[
 # Unlisted utility pages are reachable by direct URL only: they must declare
 # noindex,follow and carry basic metadata, but are exempt from the
 # indexable-page contract (Open Graph, JSON-LD, analytics, canonical, feed).
-UNLISTED_PAGES = %w[
-  archive-dig/index.html
-].freeze
+UNLISTED_PAGES = %w[].freeze
 ROUTE_LINK_EXPECTATIONS = {
   "/" => [
     { :href => "/pitch", :event => "project_inquiry_click", :location => "homepage_hero" },


### PR DESCRIPTION
/archive-dig/ becomes a first-class site page: new full-width layout (header + footer + full meta chain), all styles scoped under .archive-dig, runtime-measured sticky-header offset for the drawer rail, analytics events on card/CTA links, indexable + in sitemap (unlisted gate allowlist now empty), and a link from the projects page's past-projects section.

Verified: single h1, no nested main, JSON-LD + breadcrumbs from the layout, filters/search working, no horizontal overflow at 375px, gate green (53 indexable / 0 unlisted), self-test 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4R2C2uQr8awfCK5KsCbDm