### PR TITLE
Tighten the archive page copy

### DIFF
--- a/ideas-graveyard/index.html
+++ b/ideas-graveyard/index.html
@@ -2,7 +2,7 @@
 layout: full-width
 title: Ideas Graveyard
 seo_title: "Ideas Graveyard: DC Civic Tech Project Archive"
-description: "Civic Tech DC's records room: buried project ideas worth reviving, projects alive today, and an open drawer for new proposals."
+description: "Thirteen years of Civic Tech DC project ideas, sorted: worth reviving, superseded by better tools, or still active."
 permalink: /archive-dig/
 ---
 
@@ -582,12 +582,9 @@ permalink: /archive-dig/
       <p class="dig-eyebrow">Civic Tech DC &middot; Archive Dig</p>
       <h1>Ideas Graveyard</h1>
       <p class="dig-lede">
-        Thirteen years of Code&nbsp;for&nbsp;DC and Civic Tech DC left behind
-        nearly a hundred repositories. Most went quiet; some held genuinely good
-        ideas that ran out of runway. This is the records room:
-        <strong>files worth reviving</strong>,
-        <strong>projects alive right now</strong>, and
-        <strong>an empty drawer</strong> for the idea you haven't filed yet.
+        Since 2012, Code for DC and Civic Tech DC have piled up nearly a hundred
+        repositories. We went through all of them. Here's what's worth reviving,
+        what's been superseded by better tools, and what's still active.
       </p>
       <div class="dig-stats">
         <div class="stat">
@@ -612,41 +609,33 @@ permalink: /archive-dig/
         </div>
       </div>
       <div class="dig-lessons">
-        <p class="dig-lessons-head">Why files end up here</p>
+        <p class="dig-lessons-head">Why projects died</p>
         <p class="dig-lessons-sub">
-          Four patterns from thirteen years of stalled repos. Read them before
-          you file a new idea.
+          The same four patterns account for most of the graveyard.
         </p>
         <div class="dig-lessons-grid">
           <div class="lesson">
             <h3>Tied to one cycle</h3>
             <p>
-              Projects built for a single election, budget year, or event
-              stalled the day it passed. Design for the second cycle from day
-              one.
+              Built for one election, budget, or event. Dead the day it passed.
             </p>
           </div>
           <div class="lesson">
             <h3>Infra outlived the team</h3>
             <p>
-              Self-hosted stacks rotted once the one person who ran them moved
-              on. Choose boring, cheap hosting.
+              Self-hosted stacks rotted once the one person running them left.
             </p>
           </div>
           <div class="lesson">
             <h3>No path to the data</h3>
             <p>
-              Projects that depended on a dataset or partner that never
-              materialized stayed prototypes. Secure the data source before
-              writing code.
+              The dataset or partner never materialized, so the prototype stayed
+              one.
             </p>
           </div>
           <div class="lesson">
             <h3>One maintainer deep</h3>
-            <p>
-              When the initiating volunteer left, the project followed. Recruit
-              a co-owner early, not after the first stall.
-            </p>
+            <p>One volunteer left and the project went with them.</p>
           </div>
         </div>
       </div>
@@ -690,48 +679,36 @@ permalink: /archive-dig/
   <section class="dig-method">
     <div class="dig-wrap">
       <p>
-        <strong>How this was made.</strong> On 24 July 2026, a swarm of 97 AI
-        agents (one per repo) read each repository's README and metadata and
-        scored the underlying idea for revival potential. This is a scouting
-        report on <em>ideas</em>, not a code review &mdash; treat every
-        assessment as a lead to verify, not a verdict. Stall reasons are
-        inferred from repo evidence unless stated otherwise. In August 2026 a
-        web scan checked every dormant file against current official and public
-        tools; superseded files record what replaced them. This public version
-        is curated: private repositories, empty placeholders, mirrors of
-        external tools, and internal infrastructure repos are omitted from the
-        full scan.
+        <strong>How this was made.</strong> In July 2026, AI agents read all 97
+        public repos and scored each idea's revival potential. In August we
+        checked every dormant idea against what exists now and ran a second
+        round of agents to verify the results. Treat each note as a lead, not a
+        verdict. Private repos, empty stubs, and internal tooling are left out.
       </p>
       <p>
-        <strong>Tiers.</strong> Revive files are dormant but worth a second
-        life. Active repos were pushed within the last year &mdash; join those
-        instead of starting fresh. Superseded files record what replaced them.
-      </p>
-      <p>
-        <strong>Filing a new idea.</strong> New proposals get added by the
-        organizers. Bring yours to a
+        <strong>Have an idea?</strong> Pitch it at a
         <a
           href="{{ site.baseurl }}/events"
           data-analytics-event="event_discovery_click"
           data-analytics-location="archive_method"
           >project night</a
         >
-        or start a thread in
+        or post in
         <a
           href="{{ site.baseurl }}/slack"
           data-analytics-event="slack_discovery_click"
           data-analytics-location="archive_method"
           >Slack</a
-        >, and if it finds legs it gets a folder here with your name on it.
+        >.
       </p>
       <p>
-        Repository names link to GitHub &middot;
+        Every repo lives at
         <a
           href="https://github.com/civictechdc"
           data-analytics-event="project_repository_click"
           data-analytics-location="archive_method"
           >github.com/civictechdc</a
-        >
+        >.
       </p>
     </div>
   </section>


### PR DESCRIPTION
Concise, plainer top matter: new lede (drops stale drawer reference), "Why projects died" one-liners, shorter method section (no swarm/scouting-report language, tiers legend removed), two-line propose paragraph, matching meta description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4R2C2uQr8awfCK5KsCbDm