### PR TITLE
Add organizational initiatives page

### DIFF
--- a/_data/css-manifest.json
+++ b/_data/css-manifest.json
@@ -1,5 +1,5 @@
 {
   "civichackdc.css": "civichackdc-7c77dae101.css",
   "events.css": "events-a3db11ce2a.css",
-  "styles.css": "styles-ec2edf49b8.css"
+  "styles.css": "styles-aaa63909fa.css"
 }

--- a/_data/initiatives.yml
+++ b/_data/initiatives.yml
@@ -1,0 +1,97 @@
+# Organizational initiatives: internal programs and infrastructure that keep
+# Civic Tech DC running, each with a specific support ask. Rendered on
+# /initiatives/ by _includes/components/initiative-card.html.
+#
+# Fields:
+#   name        - display name
+#   need_label  - badge text naming the primary need (short, "Needs X")
+#   body        - what it is and why the org needs it (2-3 sentences, plain)
+#   asks        - concrete support asks (2-4 bullets)
+#   links       - optional; kind: repo | page (picks analytics event)
+
+- name: Civic Hack DC
+  need_label: Needs a venue
+  body: >-
+    Our annual civic hackathon. The 2025 edition brought more than 80
+    participants together to build on federal regulatory data, and the next
+    one is September 12, 2026. It has organizers and a theme. It does not yet
+    have a home.
+  asks:
+    - A DC venue that can host roughly 100 people on a Saturday
+    - Food and prize sponsors for the event day
+  links:
+    - text: Civic Hack DC 2025
+      url: /events/civichackdc/
+      kind: page
+
+- name: Organizational Support Fellowship
+  need_label: Needs funding
+  body: >-
+    An eight-month, part-time fellowship to build our partnership pipeline:
+    shared relationship records, outreach materials, and real discovery
+    conversations with DC nonprofits, proven on live projects. The role is
+    designed and supervised. A stipend is what makes it real.
+  asks:
+    - Stipend funding for one fellow
+    - Introductions to nonprofits that should be working with us
+
+- name: Volunteer Platform
+  need_label: Needs builders
+  body: >-
+    A volunteer directory and project showcase. Browse projects, see who works
+    on what, and find where your skills fit. The product vision and data model
+    are documented and the stack is chosen; the build needs hands to reach
+    launch.
+  asks:
+    - Next.js and Supabase contributors
+    - A design pass on the core screens
+    - A product lead to carry it to launch
+  links:
+    - text: employment-platform on GitHub
+      url: https://github.com/civictechdc/employment-platform
+      kind: repo
+
+- name: AI Literacy Workshop
+  need_label: Needs facilitators
+  body: >-
+    A workshop kit for teaching non-technical audiences how AI actually works
+    and where it fails: a slide-deck web app plus a facilitator playbook. We
+    piloted it in 2025 and nonprofits keep asking for sessions.
+  asks:
+    - Volunteer facilitators to run sessions
+    - A maintainer to keep the materials current
+    - Nonprofits that want a workshop for their staff
+  links:
+    - text: ai-literacy-workshop on GitHub
+      url: https://github.com/civictechdc/ai-literacy-workshop
+      kind: repo
+    - text: Workshop at the AI clinic
+      url: /events/ai-literacy-workshop/
+      kind: page
+
+- name: Event Automation
+  need_label: Needs a maintainer
+  body: >-
+    A TypeScript command-line tool that publishes our events to Luma and
+    Meetup in one step, with venue templates. It saves organizers hours every
+    month, and it breaks quietly whenever either platform changes something.
+  asks:
+    - A TypeScript maintainer for a few hours a month
+  links:
+    - text: ctdc-event-manager on GitHub
+      url: https://github.com/civictechdc/ctdc-event-manager
+      kind: repo
+
+- name: Project Playbook
+  need_label: Needs writers
+  body: >-
+    A documentation site collecting how we actually run things, from project
+    intake to event operations to volunteer onboarding, so the organization
+    stops living in individual organizers' heads.
+  asks:
+    - Technical writers and editors
+    - Organizers willing to turn what they know into runbooks
+  links:
+    - text: Project-Playbook on GitHub
+      url: https://github.com/civictechdc/Project-Playbook
+      kind: repo

--- a/_data/initiatives.yml
+++ b/_data/initiatives.yml
@@ -9,33 +9,21 @@
 #   asks        - concrete support asks (2-4 bullets)
 #   links       - optional; kind: repo | page (picks analytics event)
 
-- name: Civic Hack DC
-  need_label: Needs a venue
+- name: Project Playbook
+  need_label: Needs writers
   body: >-
-    Our annual civic hackathon. The 2025 edition brought more than 80
-    participants together to build on federal regulatory data, and the next
-    one is September 12, 2026. It has organizers and a theme. It does not yet
-    have a home.
+    A documentation site collecting how we actually run things, from project
+    intake to event operations to volunteer onboarding, so the organization
+    stops living in individual organizers' heads.
   asks:
-    - A DC venue that can host roughly 100 people on a Saturday
-    - Food and prize sponsors for the event day
+    - Technical writers and editors
+    - Organizers willing to turn what they know into runbooks
   links:
-    - text: Civic Hack DC 2025
-      url: /events/civichackdc/
-      kind: page
+    - text: Project-Playbook on GitHub
+      url: https://github.com/civictechdc/Project-Playbook
+      kind: repo
 
-- name: Organizational Support Fellowship
-  need_label: Needs funding
-  body: >-
-    An eight-month, part-time fellowship to build our partnership pipeline:
-    shared relationship records, outreach materials, and real discovery
-    conversations with DC nonprofits, proven on live projects. The role is
-    designed and supervised. A stipend is what makes it real.
-  asks:
-    - Stipend funding for one fellow
-    - Introductions to nonprofits that should be working with us
-
-- name: Volunteer Platform
+- name: Opportunities Platform
   need_label: Needs builders
   body: >-
     A volunteer directory and project showcase. Browse projects, see who works
@@ -51,47 +39,14 @@
       url: https://github.com/civictechdc/employment-platform
       kind: repo
 
-- name: AI Literacy Workshop
-  need_label: Needs facilitators
+- name: Civic Tech Academy
+  need_label: Needs instructors
   body: >-
-    A workshop kit for teaching non-technical audiences how AI actually works
-    and where it fails: a slide-deck web app plus a facilitator playbook. We
-    piloted it in 2025 and nonprofits keep asking for sessions.
+    A recurring training program teaching practical civic tech and data
+    skills to volunteers and the wider community. It has run informally and
+    people keep showing up; turning it into a real program needs people to
+    teach it and shape it.
   asks:
-    - Volunteer facilitators to run sessions
-    - A maintainer to keep the materials current
-    - Nonprofits that want a workshop for their staff
-  links:
-    - text: ai-literacy-workshop on GitHub
-      url: https://github.com/civictechdc/ai-literacy-workshop
-      kind: repo
-    - text: Workshop at the AI clinic
-      url: /events/ai-literacy-workshop/
-      kind: page
-
-- name: Event Automation
-  need_label: Needs a maintainer
-  body: >-
-    A TypeScript command-line tool that publishes our events to Luma and
-    Meetup in one step, with venue templates. It saves organizers hours every
-    month, and it breaks quietly whenever either platform changes something.
-  asks:
-    - A TypeScript maintainer for a few hours a month
-  links:
-    - text: ctdc-event-manager on GitHub
-      url: https://github.com/civictechdc/ctdc-event-manager
-      kind: repo
-
-- name: Project Playbook
-  need_label: Needs writers
-  body: >-
-    A documentation site collecting how we actually run things, from project
-    intake to event operations to volunteer onboarding, so the organization
-    stops living in individual organizers' heads.
-  asks:
-    - Technical writers and editors
-    - Organizers willing to turn what they know into runbooks
-  links:
-    - text: Project-Playbook on GitHub
-      url: https://github.com/civictechdc/Project-Playbook
-      kind: repo
+    - A co-organizer to run the program
+    - Instructors and curriculum contributors
+    - Organizations willing to host sessions

--- a/_includes/components/initiative-card.html
+++ b/_includes/components/initiative-card.html
@@ -1,0 +1,46 @@
+{% comment %} Organizational-initiative card for /initiatives/. Pass initiative=
+one entry from _data/initiatives.yml. The badge names the specific need (venue,
+funding, maintainer) rather than a generic status — the ask is the point of the
+page. {% endcomment %} {% assign initiative = include.initiative %}
+<li class="usa-card grid-col-12 tablet:grid-col-6 ctdc-initiative-card">
+  <div class="usa-card__container">
+    <div class="usa-card__header">
+      <span class="ctdc-project-badge ctdc-project-badge--need"
+        >{{ initiative.need_label }}</span
+      >
+      <h3 class="usa-card__heading">{{ initiative.name }}</h3>
+    </div>
+    <div class="usa-card__body">
+      <p>{{ initiative.body }}</p>
+      <p class="ctdc-initiative-card__ask-title">What we need</p>
+      <ul class="ctdc-initiative-card__asks">
+        {% for ask in initiative.asks %}
+        <li>{{ ask }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% if initiative.links %}
+    <div class="ctdc-project-card__footer">
+      {% for link in initiative.links %} {% if link.kind == 'repo' %}
+      <a
+        class="ctdc-project-card__cta ctdc-initiative-card__link"
+        href="{{ link.url }}"
+        target="_blank"
+        rel="noopener"
+        data-analytics-event="project_repository_click"
+        data-analytics-location="initiatives_page"
+        >{{ link.text }}</a
+      >
+      {% else %}
+      <a
+        class="ctdc-project-card__cta ctdc-initiative-card__link"
+        href="{{ site.baseurl }}{{ link.url }}"
+        data-analytics-event="project_discovery_click"
+        data-analytics-location="initiatives_page"
+        >{{ link.text }}</a
+      >
+      {% endif %} {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</li>

--- a/_includes/core/footer.html
+++ b/_includes/core/footer.html
@@ -124,6 +124,9 @@
                   >
                 </li>
                 <li><a href="{{ site.baseurl }}/projects">Projects</a></li>
+                <li>
+                  <a href="{{ site.baseurl }}/initiatives/">Initiatives</a>
+                </li>
                 <li><a href="{{ site.baseurl }}/slack">Join Slack</a></li>
                 <li><a href="{{ site.baseurl }}/partners">Partners</a></li>
                 <li>

--- a/_includes/core/header.html
+++ b/_includes/core/header.html
@@ -26,6 +26,11 @@
           </a>
         </li>
         <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="{{ site.baseurl }}/initiatives/"{% if page.url contains '/initiatives' %} aria-current="page"{% endif %}>
+            <span>Initiatives</span>
+          </a>
+        </li>
+        <li class="usa-nav__primary-item">
           <a class="usa-nav__link" href="{{ site.baseurl }}/events"{% if page.url contains '/events' %} aria-current="page"{% endif %}>
             <span>Events</span>
           </a>

--- a/initiatives.md
+++ b/initiatives.md
@@ -2,9 +2,9 @@
 layout: hero-image
 banner-hero: true
 title: Initiatives
-description: "The programs and infrastructure that keep Civic Tech DC running, and what each needs to continue: venues, funding, maintainers, facilitators, and writers."
+description: "The programs and infrastructure that keep Civic Tech DC running, and what each needs to continue: writers, builders, and instructors."
 hero-title: Initiatives
-hero-subtitle: "Behind our projects sits the machinery that keeps a volunteer organization running: the hackathon, the fellowship, the tools and documentation organizers rely on. Each initiative below names exactly what it needs to keep going."
+hero-subtitle: "Behind our projects sits the machinery that keeps a volunteer organization running: the playbook, the platforms, the training. Each initiative below names exactly what it needs to keep going."
 hero-image: hero-image-partners.jpg
 hero-image-alt: Civic Tech DC organizers and partners at a community event
 permalink: /initiatives/
@@ -14,7 +14,7 @@ permalink: /initiatives/
 
 Our [projects]({{ site.baseurl }}/projects.html) serve the public. These
 initiatives serve the organization, and they only move when someone puts time,
-money, or a venue behind them. Every card says what the initiative is and
+money, or skills behind them. Every card says what the initiative is and
 exactly what it needs. If one of them is yours to solve, email
 <a href="mailto:team@civictechdc.org?subject=Supporting%20a%20Civic%20Tech%20DC%20initiative" data-analytics-event="support_click" data-analytics-location="initiatives_page">team@civictechdc.org</a>
 and we will take it from there.

--- a/initiatives.md
+++ b/initiatives.md
@@ -1,0 +1,38 @@
+---
+layout: hero-image
+banner-hero: true
+title: Initiatives
+description: "The programs and infrastructure that keep Civic Tech DC running, and what each needs to continue: venues, funding, maintainers, facilitators, and writers."
+hero-title: Initiatives
+hero-subtitle: "Behind our projects sits the machinery that keeps a volunteer organization running: the hackathon, the fellowship, the tools and documentation organizers rely on. Each initiative below names exactly what it needs to keep going."
+hero-image: hero-image-partners.jpg
+hero-image-alt: Civic Tech DC organizers and partners at a community event
+permalink: /initiatives/
+---
+
+## How this works
+
+Our [projects]({{ site.baseurl }}/projects.html) serve the public. These
+initiatives serve the organization, and they only move when someone puts time,
+money, or a venue behind them. Every card says what the initiative is and
+exactly what it needs. If one of them is yours to solve, email
+<a href="mailto:team@civictechdc.org?subject=Supporting%20a%20Civic%20Tech%20DC%20initiative" data-analytics-event="support_click" data-analytics-location="initiatives_page">team@civictechdc.org</a>
+and we will take it from there.
+
+<ul class="usa-card-group ctdc-initiative-cards">
+  {% for initiative in site.data.initiatives %}
+    {% include components/initiative-card.html initiative=initiative %}
+  {% endfor %}
+</ul>
+
+<div class="ctdc-donate-cta">
+  <ul class="usa-button-group ctdc-donate-cta__buttons">
+    <li class="usa-button-group__item">
+      <a class="usa-button ctdc-donate-btn-primary" href="mailto:team@civictechdc.org?subject=Supporting%20a%20Civic%20Tech%20DC%20initiative" data-analytics-event="support_click" data-analytics-location="initiatives_page">Back an initiative</a>
+    </li>
+    <li class="usa-button-group__item">
+      <a class="usa-button ctdc-donate-btn-outline" href="{{ site.baseurl }}/support/" data-analytics-event="support_click" data-analytics-location="initiatives_page">Make a donation</a>
+    </li>
+  </ul>
+  <p class="ctdc-donate-cta__note">Civic Tech DC is a registered 501(c)(3) nonprofit. Donations are tax-deductible to the full extent allowed by law.</p>
+</div>

--- a/projects.md
+++ b/projects.md
@@ -108,6 +108,11 @@ Looking for deeper history, or an idea to pick up? The
 catalogs 13 years of project files: dormant ideas verified as still worth
 reviving, and superseded ones with a record of what replaced them.
 
+Beyond the projects themselves, our
+[organizational initiatives]({{ site.baseurl }}/initiatives/){: data-analytics-event="project_discovery_click" data-analytics-location="projects_initiatives"}
+are the programs and infrastructure that keep Civic Tech DC running, and each
+one names the specific support it needs.
+
 </div>
 
 {% include components/content-review.html %}

--- a/sass/custom/styles.scss
+++ b/sass/custom/styles.scss
@@ -1595,6 +1595,47 @@ main:has(> .ctdc-content-area + .ctdc-logo-section)
   }
 }
 
+/* Initiative cards (/initiatives/): project-card idiom, but the badge names
+   the specific need and the body carries a "What we need" ask list. */
+.ctdc-initiative-cards {
+  margin-top: 2rem;
+}
+
+.ctdc-initiative-card .usa-card__container {
+  border-top: 3px solid var(--ctdc-gold);
+}
+
+.ctdc-project-badge--need {
+  background-color: rgb(var(--ctdc-gold-rgb) / 0.15);
+  color: var(--ctdc-button-dark);
+  border: 1px solid rgb(var(--ctdc-gold-rgb) / 0.4);
+}
+
+.ctdc-initiative-card__ask-title {
+  font-size: var(--ctdc-text-2xs);
+  font-weight: var(--ctdc-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: var(--ctdc-tracking-wide);
+  color: var(--ctdc-text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.ctdc-initiative-card__asks {
+  margin: 0;
+  padding-left: 1.1rem;
+
+  li {
+    margin-bottom: 0.25rem;
+    line-height: var(--ctdc-leading-normal);
+  }
+}
+
+.ctdc-initiative-card .ctdc-project-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+}
+
 /* ==========================================================================
    17. Hero text typography
    ========================================================================== */

--- a/support.md
+++ b/support.md
@@ -29,4 +29,11 @@ Civic Tech DC is a registered 501(c)(3) nonprofit. All donations are tax-deducti
   <p class="ctdc-donate-cta__note">Contributions of any size are welcome.</p>
 </div>
 
+## Sponsor something specific
+
+Prefer to back a particular piece of the work? Our
+[organizational initiatives]({{ site.baseurl }}/initiatives/){: data-analytics-event="support_click" data-analytics-location="support_initiatives"}
+each name exactly what they need: a hackathon venue, fellowship funding, a
+maintainer, facilitators. Pick one and we will connect you to it directly.
+
 {% include components/supporters.html %}

--- a/support.md
+++ b/support.md
@@ -33,7 +33,8 @@ Civic Tech DC is a registered 501(c)(3) nonprofit. All donations are tax-deducti
 
 Prefer to back a particular piece of the work? Our
 [organizational initiatives]({{ site.baseurl }}/initiatives/){: data-analytics-event="support_click" data-analytics-location="support_initiatives"}
-each name exactly what they need: a hackathon venue, fellowship funding, a
-maintainer, facilitators. Pick one and we will connect you to it directly.
+each name exactly what they need: writers for our playbook, builders for our
+opportunities platform, instructors for our academy. Pick one and we will
+connect you to it directly.
 
 {% include components/supporters.html %}


### PR DESCRIPTION
## What

New `/initiatives/` page: organization-level programs and infrastructure, each with a badge naming its specific need and a "What we need" ask list. Sponsor/volunteer CTAs route to team@civictechdc.org and /support/. No dollar figures in v1.

**The slate (6):** Civic Hack DC (venue + food/prize sponsors), Organizational Support Fellowship (stipend funding), Volunteer Platform (builders), AI Literacy Workshop (facilitators), Event Automation (maintainer), Project Playbook (writers).

## How

- Content in `_data/initiatives.yml`, rendered by a new `initiative-card.html` include built on the project-card idiom (gold top stripe, need-badge pill, footer links)
- Page uses the standard hero-image layout, reusing the partners hero photo
- Linked from `/support/` ("Sponsor something specific") and the projects page
- Analytics reuses allowlisted events only (`support_click`, `project_repository_click`, `project_discovery_click`)
- SEO gate passes: 54 indexable pages; prettier and a11y checks clean; verified desktop + mobile rendering locally

## Review flags

- **Sept 12, 2026 hackathon date is now public** on the Civic Hack DC card — venue asks need a date, but strike it if you don't want it announced yet
- Fellowship copy avoids compensation specifics ("A stipend is what makes it real") since comp is still under discussion internally
- Slate additions beyond the three graveyard removals (per "broader org slate"): Civic Hack DC + Fellowship + Project Playbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4R2C2uQr8awfCK5KsCbDm